### PR TITLE
Fix mermaid diagram subgraph generation

### DIFF
--- a/lea/views/dag.py
+++ b/lea/views/dag.py
@@ -55,9 +55,10 @@ class DAGOfViews(graphlib.TopologicalSorter, collections.UserDict):
             self.dependencies.keys()
         )
         schema_nodes = itertools.groupby(sorted(nodes), lambda node: node[0])
-        for schema, nodes in sorted(schema_nodes):
+        for schema, nodes in schema_nodes:
             out.write(f"    subgraph {schema}\n")
-            for _, node in sorted(nodes):
+            for _, *node in sorted(nodes):
+                node = ".".join(node)
                 out.write(f"    {schema}.{node}({node})\n")
             out.write("    end\n\n")
         for dst, srcs in sorted(self.dependencies.items()):


### PR DESCRIPTION
## Issue

- Current mermaid diagram are not correctly generated, resulting in empty subgraph.
- See the jaffle_shop example ⬇️ 
![image](https://github.com/carbonfact/lea/assets/36007380/b21bf069-da46-45c1-8b9b-e00c618196a0)

## Solution
- Remove extra sort on the `schema_nodes` -> it looks like its exhausting the iterator (not 100% sure)
- handle case where `node length > 2`
    - the inner for loop will fail for a node represented by the tuple (analytics, finance, kpis)
- see diagram generated following the changes ⬇️ 
![image](https://github.com/carbonfact/lea/assets/36007380/70108f67-d2e4-449f-91c8-f6bf1f4bf1a0)
