### PR TITLE
add and run ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,8 @@ repos:
       - id: trailing-whitespace
       - id: mixed-line-ending
 
-  - repo: local
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
     hooks:
       - id: ruff
-        name: ruff
-        language: python
-        types: [python]
-        entry: ruff
+      - id: ruff-format

--- a/lea/app/test.py
+++ b/lea/app/test.py
@@ -57,7 +57,8 @@ def test(
     tests = [
         test
         for test in singular_tests + assertion_tests
-        if (
+        if
+        (
             # Run tests without any dependency whatsoever
             not (
                 test_dependencies := list(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ ignore = ["E501"]
 [tool.ruff.isort]
 required-imports = ["from __future__ import annotations"]
 
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
 [tool.pytest.ini_options]
 addopts = [
     "--doctest-modules",


### PR DESCRIPTION
as black was removed in [this commit](https://github.com/carbonfact/lea/commit/d229f6c2f47d45be38820a5c33ee6acea18ea929), I believe we should replace it with `ruff-format`