### PR TITLE
Write audit publish pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Right now lea is compatible with BigQuery (used at Carbonfact) and DuckDB (quack
     - [File structure](#file-structure)
     - [Development vs. production](#development-vs-production)
     - [Select which views to run](#select-which-views-to-run)
+    - [Write-Audit-Publish (WAP)](#write-audit-publish-wap)
     - [Workflow tips](#workflow-tips)
   - [`lea test`](#lea-test)
   - [`lea docs`](#lea-docs)
@@ -224,6 +225,18 @@ lea run --select git+  # includes all descendants
 ```
 
 This becomes very handy when using lea in continuous integration. See [dependency freezing](#dependency-freezing) for more information.
+
+#### Write-Audit-Publish (WAP)
+
+[WAP](https://lakefs.io/blog/data-engineering-patterns-write-audit-publish/) is a data engineering pattern that ensures data consistency and reliability. It's the data engineering equivalent of [blue-green deployment](https://en.wikipedia.org/wiki/Blue%E2%80%93green_deployment) in the software engineering world.
+
+By default, when you run a refresh, the tables gets progressively overwritten. This isn't necessarily a good idea. Let's say you refresh table A. Then you refresh table B that depends on A. If the refresh of B fails, you're left with a corrupted state. This is what the WAP pattern is trying to solve.
+
+With lea, the WAP patterns works by creating temporary tables in the same schema as the original tables. The temporary tables are then populated with the new data. Once the temporary tables are ready, the original tables are swapped with the temporary tables. If the refresh fails, the switch doesn't happen, and the original tables are untouched.
+
+```sh
+lea run --wap
+```
 
 #### Workflow tips
 

--- a/lea/__init__.py
+++ b/lea/__init__.py
@@ -5,5 +5,6 @@ from .dag import DAGOfViews
 from .runner import Runner
 
 _SEP = "__"
+_WAP_MODE_SUFFIX = "LEA_WAP"
 
 __all__ = ["Runner", "DAGOfViews", "cli", "clients", "diff", "views"]

--- a/lea/cli.py
+++ b/lea/cli.py
@@ -95,7 +95,7 @@ def test(
     env: str = EnvPath,
 ):
     client = _make_client(production)
-    runner = lea.Runner(views_dir=views_dir, client=client)
+    runner = lea.Runner(views_dir=views_dir, client=client, verbose=True)
     runner.test(
         select_views=select_views,
         freeze_unselected=freeze_unselected,

--- a/lea/cli.py
+++ b/lea/cli.py
@@ -79,7 +79,7 @@ def run(
         fresh=fresh,
         threads=threads,
         show=show,
-        fail_fast=fail_fast
+        fail_fast=fail_fast,
     )
 
 

--- a/lea/cli.py
+++ b/lea/cli.py
@@ -34,11 +34,9 @@ ViewsDir = typer.Argument(default="views", callback=validate_views_dir)
 
 @app.command()
 def prepare(views_dir: str = ViewsDir, production: bool = False, env: str = EnvPath):
-    client = _make_client(production)
-    views = lea.views.open_views(views_dir=views_dir, sqlglot_dialect=client.sqlglot_dialect)
-    views = [view for view in views if view.schema not in {"tests", "funcs"}]
-
-    client.prepare(views)
+    client = _make_client(production, wap_mode=False)
+    runner = lea.Runner(views_dir=views_dir, client=client, verbose=True)
+    runner.prepare()
 
 
 @app.command()
@@ -68,9 +66,10 @@ def run(
     threads: int = 8,
     show: int = 20,
     fail_fast: bool = False,
+    wap: bool = False,
     env: str = EnvPath,
 ):
-    client = _make_client(production)
+    client = _make_client(production, wap_mode=wap)
     runner = lea.Runner(views_dir=views_dir, client=client, verbose=not silent and not print)
     runner.run(
         select=select,
@@ -80,7 +79,7 @@ def run(
         fresh=fresh,
         threads=threads,
         show=show,
-        fail_fast=fail_fast,
+        fail_fast=fail_fast
     )
 
 

--- a/lea/clients/__init__.py
+++ b/lea/clients/__init__.py
@@ -8,7 +8,7 @@ from .bigquery import BigQuery
 from .duckdb import DuckDB
 
 
-def make_client(production: bool, wap_mode: bool):
+def make_client(production: bool, wap_mode=False):
     warehouse = os.environ["LEA_WAREHOUSE"]
     username = None if production else str(os.environ.get("LEA_USERNAME", getpass.getuser()))
 
@@ -28,6 +28,7 @@ def make_client(production: bool, wap_mode: bool):
             project_id=os.environ["LEA_BQ_PROJECT_ID"],
             dataset_name=os.environ["LEA_BQ_DATASET_NAME"],
             username=username,
+            wap_mode=wap_mode
         )
     elif warehouse == "duckdb":
         return DuckDB(

--- a/lea/clients/__init__.py
+++ b/lea/clients/__init__.py
@@ -28,13 +28,9 @@ def make_client(production: bool, wap_mode=False):
             project_id=os.environ["LEA_BQ_PROJECT_ID"],
             dataset_name=os.environ["LEA_BQ_DATASET_NAME"],
             username=username,
-            wap_mode=wap_mode
+            wap_mode=wap_mode,
         )
     elif warehouse == "duckdb":
-        return DuckDB(
-            path=os.environ["LEA_DUCKDB_PATH"],
-            username=username,
-            wap_mode=wap_mode
-        )
+        return DuckDB(path=os.environ["LEA_DUCKDB_PATH"], username=username, wap_mode=wap_mode)
     else:
         raise ValueError(f"Unsupported warehouse: {warehouse}")

--- a/lea/clients/__init__.py
+++ b/lea/clients/__init__.py
@@ -8,7 +8,7 @@ from .bigquery import BigQuery
 from .duckdb import DuckDB
 
 
-def make_client(production: bool):
+def make_client(production: bool, wap_mode: bool):
     warehouse = os.environ["LEA_WAREHOUSE"]
     username = None if production else str(os.environ.get("LEA_USERNAME", getpass.getuser()))
 
@@ -33,6 +33,7 @@ def make_client(production: bool):
         return DuckDB(
             path=os.environ["LEA_DUCKDB_PATH"],
             username=username,
+            wap_mode=wap_mode
         )
     else:
         raise ValueError(f"Unsupported warehouse: {warehouse}")

--- a/lea/clients/base.py
+++ b/lea/clients/base.py
@@ -103,23 +103,23 @@ class Client(abc.ABC):
 
     def make_column_test_unique(self, view: lea.views.View, column: str) -> str:
         return self.load_assertion_test_template(AssertionTag.UNIQUE).render(
-            table=self._view_key_to_table_reference(view.key, with_context=True), column=column
+            table=self._view_key_to_table_reference(view.key, with_context=False), column=column
         )
 
     def make_column_test_unique_by(self, view: lea.views.View, column: str, by: str) -> str:
         return self.load_assertion_test_template(AssertionTag.UNIQUE_BY).render(
-            table=self._view_key_to_table_reference(view.key, with_context=True), column=column, by=by
+            table=self._view_key_to_table_reference(view.key, with_context=False), column=column, by=by
         )
 
     def make_column_test_no_nulls(self, view: lea.views.View, column: str) -> str:
         return self.load_assertion_test_template(AssertionTag.NO_NULLS).render(
-            table=self._view_key_to_table_reference(view.key, with_context=True), column=column
+            table=self._view_key_to_table_reference(view.key, with_context=False), column=column
         )
 
     def make_column_test_set(self, view: lea.views.View, column: str, elements: set[str]) -> str:
         schema, *leftover = view.key
         return self.load_assertion_test_template(AssertionTag.SET).render(
-            table=self._view_key_to_table_reference(view.key, with_context=True), column=column, elements=elements
+            table=self._view_key_to_table_reference(view.key, with_context=False), column=column, elements=elements
         )
 
     def load_assertion_test_template(self, tag: str) -> jinja2.Template:

--- a/lea/clients/base.py
+++ b/lea/clients/base.py
@@ -103,23 +103,23 @@ class Client(abc.ABC):
 
     def make_column_test_unique(self, view: lea.views.View, column: str) -> str:
         return self.load_assertion_test_template(AssertionTag.UNIQUE).render(
-            table=self._view_key_to_table_reference(view.key), column=column
+            table=self._view_key_to_table_reference(view.key, with_context=True), column=column
         )
 
     def make_column_test_unique_by(self, view: lea.views.View, column: str, by: str) -> str:
         return self.load_assertion_test_template(AssertionTag.UNIQUE_BY).render(
-            table=self._view_key_to_table_reference(view.key), column=column, by=by
+            table=self._view_key_to_table_reference(view.key, with_context=True), column=column, by=by
         )
 
     def make_column_test_no_nulls(self, view: lea.views.View, column: str) -> str:
         return self.load_assertion_test_template(AssertionTag.NO_NULLS).render(
-            table=self._view_key_to_table_reference(view.key), column=column
+            table=self._view_key_to_table_reference(view.key, with_context=True), column=column
         )
 
     def make_column_test_set(self, view: lea.views.View, column: str, elements: set[str]) -> str:
         schema, *leftover = view.key
         return self.load_assertion_test_template(AssertionTag.SET).render(
-            table=self._view_key_to_table_reference(view.key), column=column, elements=elements
+            table=self._view_key_to_table_reference(view.key, with_context=True), column=column, elements=elements
         )
 
     def load_assertion_test_template(self, tag: str) -> jinja2.Template:

--- a/lea/clients/base.py
+++ b/lea/clients/base.py
@@ -108,7 +108,9 @@ class Client(abc.ABC):
 
     def make_column_test_unique_by(self, view: lea.views.View, column: str, by: str) -> str:
         return self.load_assertion_test_template(AssertionTag.UNIQUE_BY).render(
-            table=self._view_key_to_table_reference(view.key, with_context=False), column=column, by=by
+            table=self._view_key_to_table_reference(view.key, with_context=False),
+            column=column,
+            by=by,
         )
 
     def make_column_test_no_nulls(self, view: lea.views.View, column: str) -> str:
@@ -119,7 +121,9 @@ class Client(abc.ABC):
     def make_column_test_set(self, view: lea.views.View, column: str, elements: set[str]) -> str:
         schema, *leftover = view.key
         return self.load_assertion_test_template(AssertionTag.SET).render(
-            table=self._view_key_to_table_reference(view.key, with_context=False), column=column, elements=elements
+            table=self._view_key_to_table_reference(view.key, with_context=False),
+            column=column,
+            elements=elements,
         )
 
     def load_assertion_test_template(self, tag: str) -> jinja2.Template:

--- a/lea/clients/bigquery.py
+++ b/lea/clients/bigquery.py
@@ -17,7 +17,9 @@ console = rich.console.Console()
 
 
 class BigQuery(Client):
-    def __init__(self, credentials, location, project_id, dataset_name, username, wap_mode: bool = False):
+    def __init__(
+        self, credentials, location, project_id, dataset_name, username, wap_mode: bool = False
+    ):
         self.credentials = credentials
         self.project_id = project_id
         self.location = location
@@ -108,7 +110,9 @@ class BigQuery(Client):
         self.client.delete_table(f"{self.project_id}.{self.dataset_name}.{table_reference}")
 
     def _read_sql_view(self, view: lea.views.View) -> pd.DataFrame:
-        return pandas_gbq.read_gbq(view.query, credentials=self.client._credentials, progress_bar_type=None)
+        return pandas_gbq.read_gbq(
+            view.query, credentials=self.client._credentials, progress_bar_type=None
+        )
 
     def list_tables(self):
         query = f"""
@@ -159,7 +163,9 @@ class BigQuery(Client):
         table_reference = f"{self._dataset_name}.{lea._SEP.join(view_key)}"
         if with_context:
             if self.username:
-                table_reference = table_reference.replace(f"{self._dataset_name}.", f"{self.dataset_name}.")
+                table_reference = table_reference.replace(
+                    f"{self._dataset_name}.", f"{self.dataset_name}."
+                )
             if self.wap_mode:
                 table_reference = f"{table_reference}{lea._SEP}{lea._WAP_MODE_SUFFIX}"
         return table_reference
@@ -197,16 +203,18 @@ class BigQuery(Client):
         return key
 
     def switch_for_wap_mode(self, view_keys):
-
         def switch(view_key):
             table_reference = self._view_key_to_table_reference(view_key, with_context=True)
-            table_reference_without_wap = table_reference.replace(f"{lea._SEP}{lea._WAP_MODE_SUFFIX}", "")
+            table_reference_without_wap = table_reference.replace(
+                f"{lea._SEP}{lea._WAP_MODE_SUFFIX}", ""
+            )
             self.client.query(f"DROP TABLE IF EXISTS {table_reference_without_wap}").result()
             self.client.query(
                 f"ALTER TABLE {table_reference} RENAME TO {table_reference_without_wap.split('.', 1)[1]}"
             ).result()
 
         import time
+
         t = time.time()
         with concurrent.futures.ThreadPoolExecutor(max_workers=len(view_keys)) as executor:
             jobs = {executor.submit(switch, view_key): view_key for view_key in view_keys}

--- a/lea/clients/bigquery.py
+++ b/lea/clients/bigquery.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import concurrent.futures
 import os
 
 import pandas as pd
+import pandas_gbq
 import rich.console
 import sqlglot
 
@@ -15,12 +17,13 @@ console = rich.console.Console()
 
 
 class BigQuery(Client):
-    def __init__(self, credentials, location, project_id, dataset_name, username):
+    def __init__(self, credentials, location, project_id, dataset_name, username, wap_mode: bool = False):
         self.credentials = credentials
         self.project_id = project_id
         self.location = location
         self._dataset_name = dataset_name
         self.username = username
+        self.wap_mode = wap_mode
 
     @property
     def dataset_name(self):
@@ -57,7 +60,7 @@ class BigQuery(Client):
         console.log(f"Deleted dataset {dataset.dataset_id}")
 
     def _materialize_sql_query(self, view_key: tuple[str], query: str):
-        table_reference = self._view_key_to_table_reference(view_key)
+        table_reference = self._view_key_to_table_reference(view_key, with_context=True)
         schema, table_reference = table_reference.split(".", 1)
         job = self.client.create_job(
             {
@@ -74,7 +77,7 @@ class BigQuery(Client):
                 "labels": {
                     "job_dataset": self.dataset_name,
                     "job_schema": schema,
-                    "job_table": table_reference,
+                    "job_table": table_reference.replace(f"{lea._SEP}{lea._WAP_MODE_SUFFIX}", ""),
                     "job_username": self.username,
                     "job_is_github_actions": "GITHUB_ACTIONS" in os.environ,
                 },
@@ -89,7 +92,7 @@ class BigQuery(Client):
             schema=[],
             write_disposition="WRITE_TRUNCATE",
         )
-        table_reference = self._view_key_to_table_reference(view_key)
+        table_reference = self._view_key_to_table_reference(view_key, with_context=True)
         schema, table_reference = table_reference.split(".", 1)
 
         job = self.client.load_table_from_dataframe(
@@ -100,12 +103,12 @@ class BigQuery(Client):
         job.result()
 
     def delete_view_key(self, view_key: tuple[str]):
-        table_reference = self._view_key_to_table_reference(view_key)
+        table_reference = self._view_key_to_table_reference(view_key, with_context=True)
         schema, table_reference = table_reference.split(".", 1)
         self.client.delete_table(f"{self.project_id}.{self.dataset_name}.{table_reference}")
 
     def _read_sql_view(self, view: lea.views.View) -> pd.DataFrame:
-        return pd.read_gbq(view.query, credentials=self.client._credentials)
+        return pandas_gbq.read_gbq(view.query, credentials=self.client._credentials, progress_bar_type=None)
 
     def list_tables(self):
         query = f"""
@@ -129,7 +132,7 @@ class BigQuery(Client):
         view = lea.views.GenericSQLView(query=query, sqlglot_dialect=self.sqlglot_dialect)
         return self._read_sql_view(view)
 
-    def _view_key_to_table_reference(self, view_key: tuple[str], with_username: bool = None) -> str:
+    def _view_key_to_table_reference(self, view_key: tuple[str], with_context: bool) -> str:
         """
 
         >>> client = BigQuery(
@@ -140,24 +143,26 @@ class BigQuery(Client):
         ...     username="max"
         ... )
 
-        >>> client._view_key_to_table_reference(("schema", "table"), with_username=False)
+        >>> client._view_key_to_table_reference(("schema", "table"), with_context=False)
         'dataset.schema__table'
 
-        >>> client._view_key_to_table_reference(("schema", "subschema", "table"), with_username=False)
+        >>> client._view_key_to_table_reference(("schema", "subschema", "table"), with_context=False)
         'dataset.schema__subschema__table'
 
-        >>> client._view_key_to_table_reference(("schema", "table"), with_username=False)
+        >>> client._view_key_to_table_reference(("schema", "table"), with_context=False)
         'dataset.schema__table'
 
-        >>> client._view_key_to_table_reference(("schema", "table"), with_username=True)
+        >>> client._view_key_to_table_reference(("schema", "table"), with_context=True)
         'dataset_max.schema__table'
 
         """
-        if with_username is None:
-            with_username = self.username is not None
-        if with_username:
-            return f"{self.dataset_name}.{lea._SEP.join(view_key)}"
-        return f"{self._dataset_name}.{lea._SEP.join(view_key)}"
+        table_reference = f"{self._dataset_name}.{lea._SEP.join(view_key)}"
+        if with_context:
+            if self.username:
+                table_reference = table_reference.replace(f"{self._dataset_name}.", f"{self.dataset_name}.")
+            if self.wap_mode:
+                table_reference = f"{table_reference}{lea._SEP}{lea._WAP_MODE_SUFFIX}"
+        return table_reference
 
     def _table_reference_to_view_key(self, table_reference: str) -> tuple[str]:
         """
@@ -184,6 +189,48 @@ class BigQuery(Client):
 
         """
         dataset, leftover = tuple(table_reference.split(".", 1))
-        if dataset in {self._dataset_name, self.dataset_name}:
-            return tuple(leftover.split(lea._SEP))
-        return (dataset, *leftover.split(lea._SEP))
+        key = tuple(leftover.split(lea._SEP))
+        if dataset not in {self._dataset_name, self.dataset_name}:
+            key = (dataset, *key)
+        if key[-1] == lea._WAP_MODE_SUFFIX:
+            key = key[:-1]
+        return key
+
+    def switch_for_wap_mode(self, view_keys):
+
+        def switch(view_key):
+            table_reference = self._view_key_to_table_reference(view_key, with_context=True)
+            table_reference_without_wap = table_reference.replace(f"{lea._SEP}{lea._WAP_MODE_SUFFIX}", "")
+            self.client.query(f"DROP TABLE IF EXISTS {table_reference_without_wap}").result()
+            self.client.query(
+                f"ALTER TABLE {table_reference} RENAME TO {table_reference_without_wap.split('.', 1)[1]}"
+            ).result()
+
+        import time
+        t = time.time()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(view_keys)) as executor:
+            jobs = {executor.submit(switch, view_key): view_key for view_key in view_keys}
+            for job in concurrent.futures.as_completed(jobs):
+                job.result()
+        print(f"Switched {len(view_keys)} tables in {time.time() - t:.2f} seconds")
+
+        # HACK: the following doesn't work, so we process the statements sequentially
+        # statements = []
+        # for view_key in view_keys:
+        #     table_reference = self._view_key_to_table_reference(view_key, with_context=True)
+        #     table_reference_without_wap = table_reference.replace(f"{lea._SEP}{lea._WAP_MODE_SUFFIX}", "")
+        #     statements.append(f"DROP TABLE IF EXISTS {table_reference_without_wap}")
+        #     statements.append(
+        #         f"ALTER TABLE {table_reference} RENAME TO {table_reference_without_wap.split('.', 1)[1]}"
+        #     )
+        # try:
+        #     # Concatenate all the statements into one string and execute them
+        #     # sql = "\n".join(f"{statement};" for statement in statements)
+        #     # q = self.client.query(f"BEGIN TRANSACTION; {sql} COMMIT TRANSACTION;")
+        #     # q.result()
+        #     for statement in statements:
+        #         self.client.query(statement).result()
+        # except Exception as e:
+        #     # Make sure to rollback if there's an error
+        #     self.client.query("ROLLBACK TRANSACTION;")
+        #     raise e

--- a/lea/clients/duckdb.py
+++ b/lea/clients/duckdb.py
@@ -131,7 +131,9 @@ class DuckDB(Client):
         statements = []
         for view_key in view_keys:
             table_reference = self._view_key_to_table_reference(view_key, with_context=True)
-            table_reference_without_wap = table_reference.replace(lea._SEP + lea._WAP_MODE_SUFFIX, "")
+            table_reference_without_wap = table_reference.replace(
+                lea._SEP + lea._WAP_MODE_SUFFIX, ""
+            )
             statements.append(f"DROP TABLE IF EXISTS {table_reference_without_wap}")
             statements.append(
                 f"ALTER TABLE {table_reference.split('.', 1)[1]} RENAME TO {table_reference_without_wap.split('.', 2)[2]}"

--- a/lea/clients/duckdb.py
+++ b/lea/clients/duckdb.py
@@ -16,7 +16,7 @@ console = rich.console.Console()
 
 
 class DuckDB(Client):
-    def __init__(self, path: str, username: str | None = None):
+    def __init__(self, path: str, username: str | None = None, wap_mode: bool = False):
         import duckdb
 
         if path.startswith("md:"):
@@ -27,6 +27,7 @@ class DuckDB(Client):
                 path = (path.parent / f"{path.stem}_{username}{path.suffix}").absolute()
         self.path = path
         self.username = username
+        self.wap_mode = wap_mode
         self.con = duckdb.connect(str(self.path))
 
     @property
@@ -44,21 +45,19 @@ class DuckDB(Client):
             console.log(f"Created schema {schema}")
 
     def _materialize_pandas_dataframe(self, view_key: tuple[str], dataframe: pd.DataFrame):
-        self.con.sql(
-            f"CREATE OR REPLACE TABLE {self._view_key_to_table_reference(view_key)} AS SELECT * FROM dataframe"
-        )
+        table_reference = self._view_key_to_table_reference(view_key, with_context=True)
+        self.con.sql(f"CREATE OR REPLACE TABLE {table_reference} AS SELECT * FROM dataframe")
 
     def _materialize_sql_query(self, view_key: tuple[str], query: str):
-        self.con.sql(
-            f"CREATE OR REPLACE TABLE {self._view_key_to_table_reference(view_key)} AS ({query})"
-        )
+        table_reference = self._view_key_to_table_reference(view_key, with_context=True)
+        self.con.sql(f"CREATE OR REPLACE TABLE {table_reference} AS ({query})")
 
     def _read_sql_view(self, view: lea.views.SQLView):
         query = view.query
         return self.con.cursor().sql(query).df()
 
     def delete_view_key(self, view_key: tuple[str]):
-        table_reference = self._view_key_to_table_reference(view_key)
+        table_reference = self._view_key_to_table_reference(view_key, with_context=True)
         self.con.sql(f"DROP TABLE IF EXISTS {table_reference}")
 
     def teardown(self):
@@ -84,24 +83,25 @@ class DuckDB(Client):
         """
         return self.con.sql(query).df()
 
-    def _view_key_to_table_reference(self, view_key: tuple[str], with_username: bool = None) -> str:
+    def _view_key_to_table_reference(self, view_key: tuple[str], with_context: bool) -> str:
         """
 
         >>> client = DuckDB(path=":memory:", username=None)
 
-        >>> client._view_key_to_table_reference(("schema", "table"))
+        >>> client._view_key_to_table_reference(("schema", "table"), with_context=False)
         'schema.table'
 
-        >>> client._view_key_to_table_reference(("schema", "subschema", "table"))
+        >>> client._view_key_to_table_reference(("schema", "subschema", "table"), with_context=False)
         'schema.subschema__table'
 
         """
-        if with_username is None:
-            with_username = self.username is not None
         schema, *leftover = view_key
         table_reference = f"{schema}.{lea._SEP.join(leftover)}"
-        if with_username and self.username:
-            table_reference = f"{self.path.stem}.{table_reference}"
+        if with_context:
+            if self.username:
+                table_reference = f"{self.path.stem}.{table_reference}"
+            if self.wap_mode:
+                table_reference = f"{table_reference}{lea._SEP}{lea._WAP_MODE_SUFFIX}"
         return table_reference
 
     def _table_reference_to_view_key(self, table_reference: str) -> tuple[str]:
@@ -121,4 +121,26 @@ class DuckDB(Client):
             schema, leftover = leftover.split(".", 1)
         else:
             schema = database
-        return (schema, *leftover.split(lea._SEP))
+        key = (schema, *leftover.split(lea._SEP))
+        if key[-1] == lea._WAP_MODE_SUFFIX:
+            key = key[:-1]
+        return key
+
+    def switch_for_wap_mode(self, table_references):
+        statements = []
+        for table_reference in table_references:
+            # Drop the existing table if it exists
+            statements.append(f"DROP TABLE IF EXISTS {table_reference}")
+            # Rename the WAP table to the original table name
+            table_reference_without_schema = table_reference.split(".", 1)[1]
+            statements.append(
+                f"ALTER TABLE {table_reference}{lea._SEP}{lea._WAP_MODE_SUFFIX} RENAME TO {table_reference_without_schema}"
+            )
+        try:
+            # Concatenate all the statements into one string and execute them
+            sql = "\n".join(f"{statement};" for statement in statements)
+            self.con.execute(f"BEGIN TRANSACTION; {sql} COMMIT;")
+        except Exception as e:
+            # Make sure to rollback if there's an error
+            self.con.execute("ROLLBACK")
+            raise e

--- a/lea/runner.py
+++ b/lea/runner.py
@@ -257,7 +257,7 @@ class Runner:
         fresh: bool,
         threads: int,
         show: int,
-        fail_fast: bool
+        fail_fast: bool,
     ):
         # Let's determine which views need to be run
         selected_view_keys = self.select_view_keys(*select)
@@ -267,8 +267,7 @@ class Runner:
 
         # Now we determine the table reference mapping
         table_reference_mapping = self._make_table_reference_mapping(
-            selected_view_keys=selected_view_keys,
-            freeze_unselected=freeze_unselected
+            selected_view_keys=selected_view_keys, freeze_unselected=freeze_unselected
         )
 
         # Remove orphan views
@@ -628,7 +627,9 @@ class Runner:
         # HACK
         if not isinstance(self.client, lea.clients.DuckDB):
             selected_table_references = {
-                self.client._view_key_to_table_reference(view_key, with_context=False).split(".", 1)[1]
+                self.client._view_key_to_table_reference(view_key, with_context=False).split(
+                    ".", 1
+                )[1]
                 for view_key in selected_view_keys
             }
         else:

--- a/lea/runner.py
+++ b/lea/runner.py
@@ -63,6 +63,13 @@ class Runner:
 
     @property
     def regular_views(self):
+        """
+
+        What we call regular views are views that are not tests or functions.
+
+        Regular views are the views that are materialized in the database.
+
+        """
         return {
             view_key: view
             for view_key, view in self.views.items()
@@ -78,6 +85,15 @@ class Runner:
             console.print(message, **kwargs)
 
     def select_view_keys(self, *queries: str) -> set:
+        """Selects view keys from one or more graph operators.
+
+        The special case where no queries are specified is equivalent to selecting all the views.
+
+        git operators are expanded to select all the views that have been modified compared to the
+        main branch.
+
+        """
+
         def _expand_query(query):
             # It's possible to query views via git. For example:
             # * `git` will select all the views that have been modified compared to the main branch.
@@ -127,9 +143,28 @@ class Runner:
     ) -> dict[str, str]:
         """
 
-        There are two types of table_references: those that refer to a table in the current database,
-        and those that refer to a table in another database. This function determine how to rename the
-        table references in each view.
+        There are two types of table_references: those that refer to a table in the current
+        database, and those that refer to a table in another database. This function determine how
+        to rename the table references in each view.
+
+        This is important in several cases.
+
+        On the one hand, if you're refreshing views in a developper schema, the table references
+        found in each query should be renamed to target the developer schema. For instance, if a
+        query contains `FROM dwh.core__users`, we'll want to replace that with
+        `FROM dwh_max.core__users`.
+
+        On the other hand, if you're refreshing views in a production, the table references found
+        each query should be renamed to target the production schema. In general, this leaves the
+        table references untouched.
+
+        A special case is when you're refreshing views in a GitHub Actions workflow. In that case,
+        you may only want to refresh views that have been modified compared to the main branch.
+        What you'll want to do is rename the table references of modified views, while leaving the
+        others untouched. This is the so-called "Slim CI" pattern.
+
+        Note that this method only returns a mapping. It doesn't actually rename the table
+        references in a given view. That's a separate responsibility.
 
         Examples
         --------
@@ -141,10 +176,10 @@ class Runner:
 
         The client has the ability to generate table references from view keys:
 
-        >>> client._view_key_to_table_reference(('core', 'orders'))
+        >>> client._view_key_to_table_reference(('core', 'orders'), with_context=False)
         'core.orders'
 
-        >>> client._view_key_to_table_reference(('core', 'orders'), with_username=True)
+        >>> client._view_key_to_table_reference(('core', 'orders'), with_context=True)
         'jaffle_shop_max.core.orders'
 
         We can use this to generate a mapping that will rename all the table references in the views
@@ -184,10 +219,10 @@ class Runner:
         # By default, we replace all
         # table_references to the current database, but we leave the others untouched.
         if not freeze_unselected:
-            return {
+            table_reference_mapping = {
                 self.client._view_key_to_table_reference(
-                    view_key, with_username=False
-                ): self.client._view_key_to_table_reference(view_key, with_username=True)
+                    view_key, with_context=False
+                ): self.client._view_key_to_table_reference(view_key, with_context=True)
                 for view_key in self.regular_views
             }
 
@@ -198,14 +233,20 @@ class Runner:
         # Note the case where the select list is empty. That means all the views should be refreshed.
         # If freeze_unselected is specified, then it means all the views will target the production
         # database, which is basically equivalent to copying over the data.
-        if not selected_view_keys:
-            warnings.warn("Setting freeze_unselected without selecting views is not encouraged")
-        return {
-            self.client._view_key_to_table_reference(
-                view_key, with_username=False
-            ): self.client._view_key_to_table_reference(view_key, with_username=True)
-            for view_key in selected_view_keys
-        }
+        else:
+            if not selected_view_keys:
+                warnings.warn("Setting freeze_unselected without selecting views is not encouraged")
+            table_reference_mapping = {
+                self.client._view_key_to_table_reference(
+                    view_key, with_context=False
+                ): self.client._view_key_to_table_reference(view_key, with_context=True)
+                for view_key in selected_view_keys
+            }
+
+        return table_reference_mapping
+
+    def prepare(self):
+        self.client.prepare(self.regular_views.values())
 
     def run(
         self,
@@ -216,7 +257,7 @@ class Runner:
         fresh: bool,
         threads: int,
         show: int,
-        fail_fast: bool,
+        fail_fast: bool
     ):
         # Let's determine which views need to be run
         selected_view_keys = self.select_view_keys(*select)
@@ -227,10 +268,13 @@ class Runner:
         # Now we determine the table reference mapping
         table_reference_mapping = self._make_table_reference_mapping(
             selected_view_keys=selected_view_keys,
-            freeze_unselected=freeze_unselected,
+            freeze_unselected=freeze_unselected
         )
 
         # Remove orphan views
+        # It's really important to remove views that aren't part of the refresh anymore. There
+        # might be consumers that still depend on them, which is error-prone. You don't want
+        # consumers to depend on stale data.
         for table_reference in self.client.list_tables()["table_reference"]:
             view_key = self.client._table_reference_to_view_key(table_reference)
             if view_key in self.regular_views:
@@ -382,6 +426,19 @@ class Runner:
             if fail_fast:
                 raise Exception("Some views failed to build")
 
+        # In WAP mode, the tables gets created with a suffix to mimic a staging environment. We
+        # need to switch the tables to the production environment.
+        if self.client.wap_mode and not dry:
+            # In WAP mode, we want to guarantee the new tables are correct. Therefore, we run tests
+            # on them before switching.
+            self.test(
+                select_views=select,
+                freeze_unselected=freeze_unselected,
+                threads=threads,
+                fail_fast=True,
+            )
+            self.client.switch_for_wap_mode(table_references=table_reference_mapping.keys())
+
     def test(self, select_views: list[str], freeze_unselected: bool, threads: int, fail_fast: bool):
         # List all the columns
         columns = self.client.list_columns()
@@ -404,7 +461,7 @@ class Runner:
         for view in self.regular_views.values():
             # HACK: this is a bit of a hack to get the columns of the view
             view_columns = columns.query(
-                f"table_reference == '{self.client._view_key_to_table_reference(view.key, with_username=True)}'"
+                f"table_reference == '{self.client._view_key_to_table_reference(view.key, with_context=True)}'"
             )["column"].tolist()
             for test in self.client.discover_assertion_tests(view=view, view_columns=view_columns):
                 assertion_tests.append(test)
@@ -499,12 +556,12 @@ class Runner:
                 content.write(
                     "```sql\n"
                     "SELECT *\n"
-                    f"FROM {self.client._view_key_to_table_reference(view.key)}\n"
+                    f"FROM {self.client._view_key_to_table_reference(view.key, with_context=False)}\n"
                     "```\n\n"
                 )
                 # Write down the columns
                 view_columns = columns.query(
-                    f"table_reference == '{self.client._view_key_to_table_reference(view.key, with_username=True)}'"
+                    f"table_reference == '{self.client._view_key_to_table_reference(view.key, with_context=True)}'"
                 )[["column", "type"]]
                 view_comments = view.extract_comments(columns=view_columns["column"].tolist())
                 view_columns["Description"] = (
@@ -571,7 +628,7 @@ class Runner:
         # HACK
         if not isinstance(self.client, lea.clients.DuckDB):
             selected_table_references = {
-                self.client._view_key_to_table_reference(view_key).split(".", 1)[1]
+                self.client._view_key_to_table_reference(view_key, with_context=False).split(".", 1)[1]
                 for view_key in selected_view_keys
             }
         else:

--- a/lea/runner.py
+++ b/lea/runner.py
@@ -428,7 +428,7 @@ class Runner:
 
         # In WAP mode, the tables gets created with a suffix to mimic a staging environment. We
         # need to switch the tables to the production environment.
-        if self.client.wap_mode and not dry:
+        if self.client.wap_mode and not exceptions and not dry:
             # In WAP mode, we want to guarantee the new tables are correct. Therefore, we run tests
             # on them before switching.
             self.test(
@@ -437,7 +437,7 @@ class Runner:
                 threads=threads,
                 fail_fast=True,
             )
-            self.client.switch_for_wap_mode(table_references=table_reference_mapping.keys())
+            self.client.switch_for_wap_mode(selected_view_keys)
 
     def test(self, select_views: list[str], freeze_unselected: bool, threads: int, fail_fast: bool):
         # List all the columns


### PR DESCRIPTION
This works well for DuckDB.

BigQuery, alas, does not support DDL statements (i.e. rename and delete) in a transaction. So the necessary queries are run concurrently. It's not ideal, but it works quite quickly.