### PR TITLE
Fix incremental logic

### DIFF
--- a/lea/dialects.py
+++ b/lea/dialects.py
@@ -93,7 +93,7 @@ class SQLDialect:
             dependency_with_wap_suffix_str = cls.format_table_ref(dependency_with_wap_suffix)
             code = re.sub(
                 # We could use \b, but it doesn't work with backticks
-                rf"(?<!\S){re.escape(dependency_with_wap_suffix_str)}(?!\S)",
+                rf"(?<!\S){re.escape(dependency_with_wap_suffix_str)}(?=[,\s]|$)",
                 f"""
                 (
                     SELECT * FROM {dependency_with_wap_suffix_str}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "lea-cli"
 packages = [
   {include = "lea", from = "."},
 ]
-version = "0.10.0"
+version = "0.10.1"
 
 [tool.poetry.dependencies]
 click = "^8.1.7"


### PR DESCRIPTION
We detected an issue at Carbonfact, whereby incremental logic didn't pick up table names that had a trailing comma.