### PR TITLE
fix clustering fields when there are no fields

### DIFF
--- a/lea/databases.py
+++ b/lea/databases.py
@@ -332,19 +332,24 @@ class BigQueryClient(BigBluePickAPI):
         destination = BigQueryDialect.convert_table_ref_to_bigquery_table_reference(
             table_ref=sql_script.table_ref, project=self.write_project_id
         )
-        job_config = self.make_job_config(
-            script=sql_script,
-            destination=destination,
-            write_disposition="WRITE_TRUNCATE",
-            clustering_fields=(
+        clustering_fields = (
+            (
                 [
                     clustering_field
                     for clustering_field in self.default_clustering_fields
                     if clustering_field in {field.name for field in sql_script.fields}
                 ]
-                if self.default_clustering_fields and not sql_script.table_ref.is_test
-                else None
-            ),
+            )
+            if self.default_clustering_fields
+            else None
+        )
+        job_config = self.make_job_config(
+            script=sql_script,
+            destination=destination,
+            write_disposition="WRITE_TRUNCATE",
+            clustering_fields=clustering_fields
+            if clustering_fields and not sql_script.table_ref.is_test
+            else None,
         )
 
         client = (


### PR DESCRIPTION
The PR #112 introduced a bug when no clustering fields were available. BQ doesn't accept `[]` for clustering fields. It needs the value to be `None`.

For the previous PR, I only ran a dry-run which was not enough to get the problem. This time I ran a full refresh with the new code.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where clustering fields were incorrectly set when no fields were available, preventing errors during table creation.

<!-- End of auto-generated description by cubic. -->

