### PR TITLE
chore: pin external GitHub Actions to exact SHAs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,7 +12,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - uses: ./.github/actions/install-env
       - name: Run pre-commit on all files
         run: poetry run pre-commit run --all-files

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - uses: ./.github/actions/install-env
       - name: Run pytest
         run: poetry run pytest


### PR DESCRIPTION
https://app.asana.com/1/1205322658446843/project/1205827452664832/task/1210378069938795?focus=true
Update all GHA to point to SHA