### PR TITLE
fix: set active table in ducklake after init

### DIFF
--- a/lea/conductor.py
+++ b/lea/conductor.py
@@ -276,6 +276,7 @@ class Conductor:
                         USE my_ducklake;
                         """
                     )
+                    database_client.set_active_database("my_ducklake")
 
                 # When using DuckDB, we need to create schema for the tables
                 for extension in os.environ.get("LEA_DUCKDB_EXTENSIONS", "").split(","):


### PR DESCRIPTION
this is fix for #178 

Add `database_client.set_active_database("my_ducklake")` after the ATTACH/USE block in the non-quack DuckLake path in `lea/conductor.py` . This mirrors what the quack path already does.