### PR TITLE
feat: add support for apache iceberg through duckdb iceberg extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ lea parses the SQL, sees that `core.revenue` depends on `staging.customers` and 
   - [DuckDB](#duckdb)
   - [MotherDuck](#motherduck)
   - [DuckLake](#ducklake)
+- [Iceberg](#iceberg)
 - [Usage](#usage)
   - [Selecting scripts](#selecting-scripts)
   - [Development vs. production](#development-vs-production)
@@ -170,6 +171,19 @@ LEA_DUCKLAKE_CATALOG_DATABASE=metadata.ducklake
 LEA_DUCKLAKE_DATA_PATH=gcs://my-bucket/data
 LEA_DUCKLAKE_GCS_KEY_ID=GOOG1E...
 LEA_DUCKLAKE_GCS_SECRET=...
+```
+
+### Iceberg
+
+lea supports Apache Iceberg tables via [DuckDB's iceberg extension](https://duckdb.org/docs/stable/core_extensions/iceberg/overview) and a REST catalog.
+
+**Cloudflare R2 Catalog:**
+
+```sh
+LEA_WAREHOUSE=iceberg
+LEA_ICEBERG_WAREHOUSE=<warehouse>
+LEA_ICEBERG_ENDPOINT=<catalog-uri>
+LEA_ICEBERG_TOKEN=<r2_token>
 ```
 
 ## Usage

--- a/lea/conductor.py
+++ b/lea/conductor.py
@@ -45,6 +45,8 @@ class Conductor:
                 dataset_name = pathlib.Path(os.environ["LEA_MOTHERDUCK_DATABASE"]).stem
             elif self.warehouse == databases.Warehouse.DUCKLAKE:
                 dataset_name = pathlib.Path(os.environ["LEA_DUCKLAKE_DATA_PATH"]).stem
+            elif self.warehouse == databases.Warehouse.ICEBERG:
+                dataset_name = os.environ["LEA_ICEBERG_WAREHOUSE"]
             else:
                 raise ValueError(f"Unsupported warehouse {self.warehouse!r}")
         self.dataset_name = dataset_name
@@ -56,6 +58,7 @@ class Conductor:
                 databases.Warehouse.DUCKDB,
                 databases.Warehouse.MOTHERDUCK,
                 databases.Warehouse.DUCKLAKE,
+                databases.Warehouse.ICEBERG,
             }:
                 project_name = dataset_name
             else:
@@ -77,6 +80,7 @@ class Conductor:
             databases.Warehouse.DUCKDB,
             databases.Warehouse.MOTHERDUCK,
             databases.Warehouse.DUCKLAKE,
+            databases.Warehouse.ICEBERG,
         }:
             self.dag = DAGOfScripts.from_directory(
                 scripts_dir=self.scripts_dir,
@@ -276,6 +280,8 @@ class Conductor:
                         USE my_ducklake;
                         """
                     )
+                elif self.warehouse == databases.Warehouse.ICEBERG:
+                    database_client.set_active_database("iceberg_catalog")
 
                 # When using DuckDB, we need to create schema for the tables
                 for extension in os.environ.get("LEA_DUCKDB_EXTENSIONS", "").split(","):
@@ -321,6 +327,7 @@ class Conductor:
             native_dialect=native_dialect,
             native_dataset=native_dataset,
             quack_extension_setup_stmts=session_quack_setup_stmts,
+            max_workers=1 if self.warehouse == databases.Warehouse.ICEBERG else None,
         )
 
         return session
@@ -375,6 +382,7 @@ class Conductor:
         | databases.DuckDBClient
         | databases.MotherDuckClient
         | databases.DuckLakeClient
+        | databases.IcebergClient
     ):
         if self.warehouse == databases.Warehouse.BIGQUERY:
             # Do imports here to avoid loading them all the time
@@ -447,6 +455,19 @@ class Conductor:
         elif self.warehouse == databases.Warehouse.DUCKLAKE:
             return databases.DuckLakeClient(
                 database_path=pathlib.Path(os.environ["LEA_DUCKLAKE_DATA_PATH"]),
+                dry_run=dry_run,
+                print_mode=print_mode,
+            )
+
+        elif self.warehouse == databases.Warehouse.ICEBERG:
+            return databases.IcebergClient(
+                database_path=pathlib.Path(os.environ["LEA_ICEBERG_WAREHOUSE"]),
+                warehouse=os.environ["LEA_ICEBERG_WAREHOUSE"],
+                endpoint=os.environ["LEA_ICEBERG_ENDPOINT"],
+                token=os.environ.get("LEA_ICEBERG_TOKEN"),
+                client_id=os.environ.get("LEA_ICEBERG_CLIENT_ID"),
+                client_secret=os.environ.get("LEA_ICEBERG_CLIENT_SECRET"),
+                oauth2_server_uri=os.environ.get("LEA_ICEBERG_OAUTH2_SERVER_URI"),
                 dry_run=dry_run,
                 print_mode=print_mode,
             )
@@ -846,6 +867,11 @@ def promote_audit_tables(session: Session):
             lea.log.error(f"Promotion failed\n{exception}")
 
 
+def _make_delete_executor(session: Session) -> concurrent.futures.ThreadPoolExecutor:
+    max_workers = 1 if session.warehouse == databases.Warehouse.ICEBERG else None
+    return concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+
+
 def delete_audit_tables(session: Session):
     # Depending on when delete_audit_tables is called, there might be new audit tables that have
     # been created. We need to delete them too. We do this by adding the write context to the
@@ -876,7 +902,7 @@ def delete_audit_tables(session: Session):
             delete_table_refs(
                 table_refs=native_audit_refs,
                 database_client=session.database_client,
-                executor=concurrent.futures.ThreadPoolExecutor(max_workers=None),
+                executor=_make_delete_executor(session),
                 verbose=False,
             )
         if duck_audit_refs and session.quack_database_client is not None:
@@ -886,7 +912,7 @@ def delete_audit_tables(session: Session):
             delete_table_refs(
                 table_refs=duck_audit_refs,
                 database_client=session.quack_database_client,
-                executor=concurrent.futures.ThreadPoolExecutor(max_workers=None),
+                executor=_make_delete_executor(session),
                 verbose=False,
             )
     elif table_refs_to_delete and session.database_client is not None:
@@ -897,7 +923,7 @@ def delete_audit_tables(session: Session):
         delete_table_refs(
             table_refs=table_refs_to_delete,
             database_client=session.database_client,
-            executor=concurrent.futures.ThreadPoolExecutor(max_workers=None),
+            executor=_make_delete_executor(session),
             verbose=False,
         )
     session.existing_audit_tables = {}
@@ -913,7 +939,7 @@ def delete_orphan_tables(session: Session):
         delete_table_refs(
             table_refs=table_refs_to_delete,
             database_client=session.database_client,
-            executor=concurrent.futures.ThreadPoolExecutor(max_workers=None),
+            executor=_make_delete_executor(session),
             verbose=True,
         )
         session.existing_audit_tables = {}

--- a/lea/databases.py
+++ b/lea/databases.py
@@ -32,6 +32,7 @@ class Warehouse(enum.Enum):
     DUCKDB = "duckdb"
     MOTHERDUCK = "motherduck"
     DUCKLAKE = "ducklake"
+    ICEBERG = "iceberg"
 
     @property
     def display_name(self) -> str:
@@ -40,6 +41,7 @@ class Warehouse(enum.Enum):
             Warehouse.DUCKDB: "DuckDB",
             Warehouse.MOTHERDUCK: "MotherDuck",
             Warehouse.DUCKLAKE: "DuckLake",
+            Warehouse.ICEBERG: "Iceberg",
         }[self]
 
     @property
@@ -50,6 +52,7 @@ class Warehouse(enum.Enum):
             Warehouse.DUCKDB: "green",
             Warehouse.MOTHERDUCK: "magenta",
             Warehouse.DUCKLAKE: "dark_orange",
+            Warehouse.ICEBERG: "cyan",
         }[self]
         return f"[{color}]{self.display_name}[/{color}]"
 
@@ -944,4 +947,218 @@ class DuckLakeClient(DuckDBClient):
         SELECT table_name, schema_name, estimated_size
         FROM duckdb_tables()
         WHERE NOT STARTS_WITH(table_name, 'ducklake_') {db_filter};
+        """
+
+
+class IcebergClient(DuckDBClient):
+    CATALOG_ALIAS = "iceberg_catalog"
+
+    def __init__(
+        self,
+        *args,
+        warehouse: str,
+        endpoint: str,
+        token: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        oauth2_server_uri: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self._conn = duckdb.connect()
+        self._active_database: str | None = None
+        self._warehouse = warehouse
+        self._endpoint = endpoint
+
+        self._conn.execute("INSTALL iceberg; LOAD iceberg;")
+
+        if token:
+            self._conn.execute(f"CREATE SECRET iceberg_secret (TYPE iceberg, TOKEN '{token}');")
+        elif client_id and client_secret:
+            secret_sql = (
+                f"CREATE SECRET iceberg_secret (TYPE iceberg, "
+                f"CLIENT_ID '{client_id}', CLIENT_SECRET '{client_secret}'"
+            )
+            if oauth2_server_uri:
+                secret_sql += f", OAUTH2_SERVER_URI '{oauth2_server_uri}'"
+            secret_sql += ");"
+            self._conn.execute(secret_sql)
+        else:
+            self._conn.execute(
+                "CREATE SECRET iceberg_secret (TYPE iceberg, AUTHORIZATION_TYPE 'none');"
+            )
+
+        self._conn.execute(
+            f"ATTACH '{warehouse}' AS {self.CATALOG_ALIAS} (TYPE iceberg, ENDPOINT '{endpoint}');"
+        )
+
+    @property
+    def connection(self) -> duckdb.DuckDBPyConnection:
+        return self._conn
+
+    def set_active_database(self, database_name: str):
+        self._active_database = database_name
+
+    def create_dataset(self, dataset_name: str):
+        pass
+
+    def _format_fqt(self, table_ref: scripts.TableRef) -> str:
+        return f"{self.CATALOG_ALIAS}.{DuckDBDialect.convert_table_ref_to_duckdb_table_reference(table_ref)}"
+
+    def create_schema(self, schema_name: str):
+        self._conn.execute(f"CREATE SCHEMA IF NOT EXISTS {self.CATALOG_ALIAS}.{schema_name}")
+
+    def _drop_table_if_exists(self, table_ref: scripts.TableRef):
+        fqt = self._format_fqt(table_ref)
+        schema = table_ref.schema[0] if table_ref.schema else "main"
+        cursor = self._conn.cursor()
+        cursor.execute(f"USE {self.CATALOG_ALIAS}.{schema};")
+        cursor.execute(f"DROP TABLE IF EXISTS {fqt}")
+
+    def materialize_sql_script(self, sql_script: scripts.SQLScript) -> DuckDBJob:
+        if sql_script.header_statements:
+            raise ValueError("Header statements are not (yet) supported for Iceberg")
+
+        destination = self._format_fqt(sql_script.table_ref)
+        self._drop_table_if_exists(sql_script.table_ref)
+
+        materialize_code = f"""
+        CREATE TABLE {destination} AS (
+        WITH logic_table AS ({sql_script.query}),
+        materialized_infos AS (SELECT CURRENT_LOCALTIMESTAMP() AS _materialized_timestamp)
+        SELECT * FROM logic_table, materialized_infos
+        );
+        """
+        return self.make_job_config(
+            script=scripts.SQLScript(
+                table_ref=sql_script.table_ref,
+                code=materialize_code,
+                sql_dialect=DuckDBDialect(),
+                fields=[],
+            ),
+            destination=destination,
+        )
+
+    def clone_table(
+        self, from_table_ref: scripts.TableRef, to_table_ref: scripts.TableRef
+    ) -> DuckDBJob:
+        destination = self._format_fqt(to_table_ref)
+        source = self._format_fqt(from_table_ref)
+        self._drop_table_if_exists(to_table_ref)
+
+        clone_code = f"""
+        CREATE TABLE {destination} AS SELECT * FROM {source};
+        """
+        return self.make_job_config(
+            script=scripts.SQLScript(
+                table_ref=to_table_ref, code=clone_code, sql_dialect=DuckDBDialect(), fields=[]
+            ),
+            destination=destination,
+        )
+
+    def delete_and_insert(
+        self, from_table_ref: scripts.TableRef, to_table_ref: scripts.TableRef, on: str
+    ) -> DuckDBJob:
+        to_ref = self._format_fqt(to_table_ref)
+        from_ref = self._format_fqt(from_table_ref)
+        delete_and_insert_code = f"""
+        DELETE FROM {to_ref} WHERE {on} IN (SELECT DISTINCT {on} FROM {from_ref});
+        INSERT INTO {to_ref} SELECT * FROM {from_ref};
+        """
+        job = self.make_job_config(
+            script=scripts.SQLScript(
+                table_ref=to_table_ref,
+                code=delete_and_insert_code,
+                sql_dialect=DuckDBDialect(),
+                fields=[],
+            ),
+            destination=to_ref,
+        )
+        job.execute()
+        return job
+
+    def delete_table(self, table_ref: scripts.TableRef) -> DuckDBJob:
+        self._drop_table_if_exists(table_ref)
+        job = self.make_job_config(
+            script=scripts.SQLScript(
+                table_ref=table_ref, code="SELECT 1", sql_dialect=DuckDBDialect(), fields=[]
+            )
+        )
+        return job
+
+    def make_job_config(
+        self, script: scripts.SQLScript, destination: str | None = None
+    ) -> DuckDBJob:
+        if self.print_mode:
+            rich.print(script)
+        cursor = self._conn.cursor()
+        schema = script.table_ref.schema[0] if script.table_ref.schema else "main"
+        cursor.execute(f"USE {self.CATALOG_ALIAS}.{schema};")
+        return DuckDBJob(query=script.query, connection=cursor, destination=destination)
+
+    def list_table_stats(self, dataset_name: str) -> dict[TableRef, TableStats]:
+        import pandas as pd
+
+        from lea.dialects import DuckDBDialect
+
+        cursor = self._conn.cursor()
+        tables_result = cursor.execute(self._tables_query).fetchdf()
+        table_stats = {}
+        for _, row in tables_result.iterrows():
+            table_name = row["table_name"]
+            table_schema = row["schema_name"]
+            n_rows = int(row["estimated_size"]) if not pd.isna(row["estimated_size"]) else None
+            fqt = f"{self.CATALOG_ALIAS}.{table_schema}.{table_name}"
+            stats_cursor = self._conn.cursor()
+            result = (
+                stats_cursor.execute(
+                    f"SELECT MAX(_materialized_timestamp) AS last_modified FROM {fqt}"
+                )
+                .fetchdf()
+                .dropna()
+            )
+            if result.empty:
+                updated_at = dt.datetime.now(dt.UTC)
+            else:
+                updated_at = dt.datetime.fromtimestamp(
+                    result.iloc[0]["last_modified"].to_pydatetime().timestamp(),
+                    tz=dt.UTC,
+                )
+            table_stats[
+                DuckDBDialect.parse_table_ref(f"{table_schema}.{table_name}").replace_dataset(
+                    dataset_name
+                )
+            ] = TableStats(
+                n_rows=n_rows,
+                n_bytes=None,
+                updated_at=updated_at,
+            )
+        return table_stats
+
+    def list_table_fields(self, dataset_name: str) -> dict[scripts.TableRef, list[scripts.Field]]:
+        from lea.dialects import DuckDBDialect
+
+        cursor = self._conn.cursor()
+        query = (
+            "SELECT table_schema, table_name, column_name "
+            "FROM information_schema.columns "
+            f"WHERE table_catalog = '{self.CATALOG_ALIAS}'"
+        )
+        result = cursor.execute(query).fetchdf()
+        table_fields = {}
+        for (table_schema, table_name), rows in result.groupby(["table_schema", "table_name"]):
+            table_ref = DuckDBDialect.parse_table_ref(
+                f"{table_schema}.{table_name}"
+            ).replace_dataset(dataset_name)
+            table_fields[table_ref] = [
+                scripts.Field(name=row["column_name"]) for _, row in rows.iterrows()
+            ]
+        return table_fields
+
+    @property
+    def _tables_query(self) -> str:
+        return f"""
+        SELECT table_name, schema_name, estimated_size
+        FROM duckdb_tables()
+        WHERE database_name = '{self.CATALOG_ALIAS}';
         """

--- a/lea/session.py
+++ b/lea/session.py
@@ -44,6 +44,7 @@ class Session:
         native_dialect: SQLDialect | None = None,
         native_dataset: str | None = None,
         quack_extension_setup_stmts: list[str] | None = None,
+        max_workers: int | None = None,
     ):
         self.database_client = database_client
         self.base_dataset = base_dataset
@@ -69,7 +70,7 @@ class Session:
         self.jobs: list[Job] = []
         self.started_at = dt.datetime.now()
         self.ended_at: dt.datetime | None = None
-        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=None)
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
         self.run_script_futures: dict = {}
         self.run_script_futures_complete: dict = {}
         self.promote_audit_tables_futures: dict = {}
@@ -243,7 +244,7 @@ class Session:
 
     @property
     def warehouse(self) -> Warehouse | None:
-        from lea.databases import BigQueryClient, MotherDuckClient
+        from lea.databases import BigQueryClient, IcebergClient, MotherDuckClient
 
         if self.database_client is None:
             return None
@@ -251,6 +252,8 @@ class Session:
             return Warehouse.BIGQUERY
         if isinstance(self.database_client, MotherDuckClient):
             return Warehouse.MOTHERDUCK
+        if isinstance(self.database_client, IcebergClient):
+            return Warehouse.ICEBERG
         if isinstance(self.database_client, DuckLakeClient):
             return Warehouse.DUCKLAKE
         return Warehouse.DUCKDB


### PR DESCRIPTION
Tested using Cloudflare R2 REST catalog

<img width="1920" height="1032" alt="Screenshot 2026-04-13 005452" src="https://github.com/user-attachments/assets/d6bc820f-efcb-49ea-ade1-dc8d40ae0406" />
<img width="1920" height="1032" alt="Screenshot 2026-04-13 005701" src="https://github.com/user-attachments/assets/949af738-1027-4205-8c17-4ce88b7e75f9" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Apache Iceberg support using the `duckdb` Iceberg extension and a REST catalog. You can now run LEA against Iceberg tables (tested with Cloudflare R2).

- New Features
  - Added `Warehouse.ICEBERG` with `IcebergClient` built on `duckdb`’s Iceberg extension (`ATTACH` as `iceberg_catalog`).
  - Supports token or OAuth2 client credentials for REST catalogs.
  - Table ops: create-as-select, clone, delete-and-insert, and delete; lists tables, fields, and stats.
  - Serialized execution for Iceberg (max_workers=1) and catalog selection via `USE iceberg_catalog`.
  - Note: header statements are not supported for Iceberg scripts.

- Migration
  - Set env vars:
    - `LEA_WAREHOUSE=iceberg`
    - `LEA_ICEBERG_WAREHOUSE`, `LEA_ICEBERG_ENDPOINT`
    - Auth: `LEA_ICEBERG_TOKEN` or `LEA_ICEBERG_CLIENT_ID`/`LEA_ICEBERG_CLIENT_SECRET` (optional `LEA_ICEBERG_OAUTH2_SERVER_URI`)
  - The `duckdb` Iceberg extension is installed and loaded automatically.

<sup>Written for commit ad75ba7bf5b53b212eb6350a7313f845a8491bc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

