### PR TITLE
refactor(bigquery): route via SET @@reservation instead of multi-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,26 +362,31 @@ FROM my_table
 
 Table-specific clustering fields are added *in addition to* the default ones.
 
-#### Script-specific compute projects
+#### Script-specific reservations
 
-You can route specific scripts to different compute projects:
+By default every query runs under whatever [reservation assignment](https://cloud.google.com/bigquery/docs/reservations-assignments) is attached to `LEA_BQ_COMPUTE_PROJECT_ID` at the GCP level — or on-demand if none. You can override that per script, in either direction, using BigQuery's `SET @@reservation` [system variable](https://docs.cloud.google.com/bigquery/docs/reservations-assignments#sql_3):
 
 ```sh
-LEA_BQ_SCRIPT_SPECIFIC_COMPUTE_PROJECT_IDS={"dataset.schema__table": "reservation-project-id"}
+# Force specific scripts to on-demand even if the compute project has a reservation.
+LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS={"dataset.schema__table": "none"}
+
+# Or route specific scripts to a reservation even if the compute project has none.
+LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS={"dataset.schema__table": "projects/P/locations/EU/reservations/R"}
 ```
 
-Scripts not listed use the default `LEA_BQ_COMPUTE_PROJECT_ID`.
+lea emits `SET @@reservation = '<value>'` in a session before running the query. Scripts not listed inherit the compute project's assignment.
 
 #### Big Blue Pick API
 
-[Big Blue](https://biq.blue/) provides a [Pick API](https://biq.blue/blog/compute/how-to-implement-bigquery-autoscaling-reservation-in-10-minutes) that suggests whether to run a query on-demand or on a reservation. lea supports this out of the box:
+[Big Blue](https://biq.blue/) provides a [Pick API](https://biq.blue/blog/compute/how-to-implement-bigquery-autoscaling-reservation-in-10-minutes) that suggests per-query whether to run on-demand or on a reservation. lea supports it out of the box:
 
 ```sh
 LEA_BQ_BIG_BLUE_PICK_API_KEY=<get from https://your-company.biq.blue/settings.html>
 LEA_BQ_BIG_BLUE_PICK_API_URL=https://pick.biq.blue
-LEA_BQ_BIG_BLUE_PICK_API_ON_DEMAND_PROJECT_ID=on-demand-compute-project-id
-LEA_BQ_BIG_BLUE_PICK_API_REVERVATION_PROJECT_ID=reservation-compute-project-id
+LEA_BQ_BIG_BLUE_PICK_API_RESERVATION=projects/P/locations/EU/reservations/R
 ```
+
+When Pick API returns `ON-DEMAND`, lea sets `@@reservation = 'none'`; when it returns `RESERVATION`, lea sets it to `LEA_BQ_BIG_BLUE_PICK_API_RESERVATION`. `LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS` takes priority over Pick API — deliberately routed scripts aren't re-routed behind your back.
 
 ## Examples
 

--- a/lea/conductor.py
+++ b/lea/conductor.py
@@ -384,16 +384,22 @@ class Conductor:
                 is not None
                 else None
             )
+            compute_project_id = os.environ.get(
+                "LEA_BQ_COMPUTE_PROJECT_ID",
+                credentials.project_id if credentials is not None else None,
+            )
+            if compute_project_id is None:
+                raise ValueError(
+                    "LEA_BQ_COMPUTE_PROJECT_ID must be set (or a service account credential "
+                    "must provide a project_id)"
+                )
             client = databases.BigQueryClient(
                 credentials=credentials,
                 location=os.environ["LEA_BQ_LOCATION"],
                 write_project_id=os.environ["LEA_BQ_PROJECT_ID"],
-                compute_project_id=os.environ.get(
-                    "LEA_BQ_COMPUTE_PROJECT_ID",
-                    credentials.project_id if credentials is not None else None,
-                ),
-                script_specific_compute_project_ids=parse_bigquery_script_specific_compute_project_ids(
-                    env_var=os.environ.get("LEA_BQ_SCRIPT_SPECIFIC_COMPUTE_PROJECT_IDS"),
+                compute_project_id=compute_project_id,
+                script_specific_reservations=parse_bigquery_script_specific_reservations(
+                    env_var=os.environ.get("LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS"),
                     dataset_name=(
                         self.dataset_name if production else self.dataset_name_with_username
                     ),
@@ -411,11 +417,8 @@ class Conductor:
                 ],
                 big_blue_pick_api_url=os.environ.get("LEA_BQ_BIG_BLUE_PICK_API_URL"),
                 big_blue_pick_api_key=os.environ.get("LEA_BQ_BIG_BLUE_PICK_API_KEY"),
-                big_blue_pick_api_on_demand_project_id=os.environ.get(
-                    "LEA_BQ_BIG_BLUE_PICK_API_ON_DEMAND_PROJECT_ID"
-                ),
-                big_blue_pick_api_reservation_project_id=os.environ.get(
-                    "LEA_BQ_BIG_BLUE_PICK_API_REVERVATION_PROJECT_ID"
+                big_blue_pick_api_reservation=os.environ.get(
+                    "LEA_BQ_BIG_BLUE_PICK_API_RESERVATION"
                 ),
             )
             if client.big_blue_pick_api is not None:
@@ -996,20 +999,33 @@ def determine_table_refs_to_run(
     return table_refs_to_run
 
 
-def parse_bigquery_script_specific_compute_project_ids(
+def parse_bigquery_script_specific_reservations(
     env_var: str | None,
     dataset_name: str,
     write_project_id: str,
 ) -> dict[scripts.TableRef, str]:
+    """Parse ``LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS`` JSON into a ``TableRef → reservation`` map.
+
+    Values are either ``"none"`` (to force on-demand) or a fully-qualified reservation path
+    ``projects/P/locations/L/reservations/R``. Anything else raises — surfacing the typo at
+    startup is much friendlier than a BigQuery error mid-run.
+    """
     if env_var is None:
         return {}
     mapping = json.loads(env_var)
+    for table_ref_str, reservation in mapping.items():
+        if reservation != "none" and not reservation.startswith("projects/"):
+            raise ValueError(
+                f"Invalid reservation {reservation!r} for {table_ref_str!r} in "
+                "LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS: expected 'none' or "
+                "'projects/.../reservations/...'"
+            )
     return {
         (
             BigQueryDialect.parse_table_ref(table_ref_str)
             .replace_dataset(dataset_name)
             .replace_project(write_project_id)
             .add_audit_suffix()
-        ): compute_project_id
-        for table_ref_str, compute_project_id in mapping.items()
+        ): reservation
+        for table_ref_str, reservation in mapping.items()
     }

--- a/lea/databases.py
+++ b/lea/databases.py
@@ -133,13 +133,14 @@ class BigQueryJob:
 
         if self.client.dry_run or self.destination is None:
             return None
-        table = self.client.default_client.get_table(
+        table = self.client.client.get_table(
             self.destination, retry=bigquery.DEFAULT_RETRY.with_deadline(10)
         )
         return TableStats(n_rows=table.num_rows, n_bytes=table.num_bytes, updated_at=table.modified)
 
     def stop(self):
-        self.client.default_client.cancel_job(self.query_job.job_id)
+        if self.query_job.job_id is not None:
+            self.client.client.cancel_job(self.query_job.job_id)
 
     @property
     def result(self) -> pd.DataFrame:
@@ -150,16 +151,22 @@ class BigQueryJob:
         return self.query_job.exception()
 
     @property
-    def is_using_reservation(self) -> bool:
-        return (
-            self.query_job._properties.get("statistics", {})
-            .get("reservationUsage", [{}])[0]
-            .get("name")
-        ) is not None
+    def reservation_id(self) -> str | None:
+        """The reservation the job actually ran under, or ``None`` for on-demand.
+
+        BigQuery exposes this at ``statistics.reservation_id`` (e.g.
+        ``"int-data-kaya-prod:EU.default"``). The older ``reservationUsage`` field only
+        fires for slot-consuming queries and is unreliable — don't read from it.
+        """
+        return self.query_job._properties.get("statistics", {}).get("reservation_id")
 
     @property
     def metadata(self) -> list[str]:
-        billing_model = ("reservation" if self.is_using_reservation else "on-demand") + " billing"
+        billing_model = (
+            f"reservation billing ({self.reservation_id})"
+            if self.reservation_id is not None
+            else "on-demand billing"
+        )
         return [billing_model]
 
     def conclude(self):
@@ -176,36 +183,28 @@ class TableStats:
     updated_at: dt.datetime | None
 
 
+ON_DEMAND_RESERVATION = "none"
+
+
 class BigBluePickAPI:
     """Big Blue Pick API implementation.
 
     https://biq.blue/blog/compute/how-to-implement-bigquery-autoscaling-reservation-in-10-minutes
 
-    Parameters
-    ----------
-    on_demand_project_id
-        The project ID of the on-demand BigQuery project.
-    reservation_project_id
-        The project ID of the reservation BigQuery project.
-    default_project_id
-        The project ID of the default BigQuery project. This is used if something with the
-        BigBlue Pick API fails.
-
+    Given a script, the Pick API returns either ``"ON-DEMAND"`` or ``"RESERVATION"``. We translate
+    those to a value for the BigQuery ``@@reservation`` system variable: ``"none"`` for on-demand,
+    and the caller-supplied reservation path for the reservation case.
     """
 
     def __init__(
         self,
         api_url: str,
         api_key: str,
-        on_demand_project_id: str,
-        reservation_project_id: str,
-        default_project_id: str,
+        reservation: str,
     ):
         self.api_url = api_url
         self.api_key = api_key
-        self.on_demand_project_id = on_demand_project_id
-        self.reservation_project_id = reservation_project_id
-        self.default_project_id = default_project_id
+        self.reservation = reservation
 
     def call_pick_api(self, path, body):
         try:
@@ -229,22 +228,23 @@ class BigBluePickAPI:
             str(script.table_ref.replace_dataset("FREEZE").replace_project("FREEZE")).encode()
         ).hexdigest()
 
-    def pick_project_id_for_script(self, script: scripts.SQLScript) -> str:
+    def pick_reservation_for_script(self, script: scripts.SQLScript) -> str | None:
+        """Return the reservation identifier to use for this script, or None to fall back."""
         response = self.call_pick_api(
             path="/pick",
             body={"hash": self.hash_script(script)},
         )
         if not response or not (pick := response.get("pick")):
-            lea.log.warning("Big Blue Pick API call failed, using default project ID")
-        elif pick not in {"ON-DEMAND", "RESERVATION"}:
-            lea.log.warning(
-                f"Big Blue Pick API returned unexpected choice {response['pick']!r}, using default project ID"
-            )
-        elif pick == "ON-DEMAND":
-            return self.on_demand_project_id
-        elif pick == "RESERVATION":
-            return self.reservation_project_id
-        return self.default_project_id
+            lea.log.warning("Big Blue Pick API call failed, falling back to default reservation")
+            return None
+        if pick == "ON-DEMAND":
+            return ON_DEMAND_RESERVATION
+        if pick == "RESERVATION":
+            return self.reservation
+        lea.log.warning(
+            f"Big Blue Pick API returned unexpected choice {pick!r}, falling back to default reservation"
+        )
+        return None
 
     def record_job_for_script(self, script: scripts.SQLScript, job: bigquery.QueryJob):
         self.call_pick_api(
@@ -271,41 +271,30 @@ class BigBluePickAPI:
         )
 
 
-class BigQueryClient(BigBluePickAPI):
+class BigQueryClient:
     def __init__(
         self,
         credentials: service_account.Credentials | None,
         location: str,
         write_project_id: str,
-        compute_project_id: str | None,
-        script_specific_compute_project_ids: dict[scripts.TableRef, str] | None = None,
+        compute_project_id: str,
+        script_specific_reservations: dict[scripts.TableRef, str] | None = None,
         storage_billing_model: str = "PHYSICAL",
         dry_run: bool = False,
         print_mode: bool = False,
         default_clustering_fields: list[str] | None = None,
         big_blue_pick_api_url: str | None = None,
         big_blue_pick_api_key: str | None = None,
-        big_blue_pick_api_on_demand_project_id: str | None = None,
-        big_blue_pick_api_reservation_project_id: str | None = None,
+        big_blue_pick_api_reservation: str | None = None,
     ):
 
         self.credentials = credentials
         self.write_project_id = write_project_id
         self.compute_project_id = compute_project_id
-        self.script_specific_compute_project_ids = script_specific_compute_project_ids or {}
+        self.script_specific_reservations = script_specific_reservations or {}
         self.storage_billing_model = storage_billing_model
         self.location = location
-        self.clients = {
-            project_id: self._make_client(project_id)
-            for project_id in {
-                self.compute_project_id,
-                *(self.script_specific_compute_project_ids.values()),
-                big_blue_pick_api_on_demand_project_id,
-                big_blue_pick_api_reservation_project_id,
-                self.write_project_id,
-            }
-            if project_id is not None
-        }
+        self.client = self._make_client(compute_project_id)
         self.dry_run = dry_run
         self.print_mode = print_mode
         self.default_clustering_fields = default_clustering_fields or []
@@ -314,15 +303,12 @@ class BigQueryClient(BigBluePickAPI):
             BigBluePickAPI(
                 api_url=big_blue_pick_api_url,
                 api_key=big_blue_pick_api_key,
-                on_demand_project_id=big_blue_pick_api_on_demand_project_id,
-                reservation_project_id=big_blue_pick_api_reservation_project_id,
-                default_project_id=self.write_project_id,
+                reservation=big_blue_pick_api_reservation,
             )
             if (
                 big_blue_pick_api_url is not None
                 and big_blue_pick_api_key is not None
-                and big_blue_pick_api_on_demand_project_id is not None
-                and big_blue_pick_api_reservation_project_id is not None
+                and big_blue_pick_api_reservation is not None
             )
             else None
         )
@@ -347,10 +333,6 @@ class BigQueryClient(BigBluePickAPI):
         client._http.mount("https://", adapter)
         return client
 
-    @property
-    def default_client(self) -> bigquery.Client:
-        return self.clients[self.compute_project_id]
-
     def create_dataset(self, dataset_name: str):
         from google.cloud import bigquery
 
@@ -360,10 +342,10 @@ class BigQueryClient(BigBluePickAPI):
         dataset = bigquery.Dataset(dataset_ref)
         dataset.location = self.location
         dataset.storage_billing_model = self.storage_billing_model
-        dataset = self.default_client.create_dataset(dataset, exists_ok=True)
+        dataset = self.client.create_dataset(dataset, exists_ok=True)
 
     def delete_dataset(self, dataset_name: str):
-        self.default_client.delete_dataset(
+        self.client.delete_dataset(
             dataset=f"{self.write_project_id}.{dataset_name}",
             delete_contents=True,
             not_found_ok=True,
@@ -379,19 +361,63 @@ class BigQueryClient(BigBluePickAPI):
             return self.materialize_sql_script(sql_script=script)
         raise ValueError("Unsupported script type")
 
-    def determine_client_for_script(self, sql_script: scripts.SQLScript) -> bigquery.Client:
-        project_id = (
-            self.big_blue_pick_api.pick_project_id_for_script(script=sql_script)
-            if self.big_blue_pick_api is not None
-            else self.script_specific_compute_project_ids.get(
-                sql_script.table_ref, self.compute_project_id
-            )
-        )
-        return self.clients[project_id]
+    def determine_reservation_for_script(self, sql_script: scripts.SQLScript) -> str | None:
+        """Resolve which reservation to set via ``SET @@reservation`` for this script.
 
-    def materialize_sql_script(self, sql_script: scripts.SQLScript) -> BigQueryJob:
+        Precedence: script-specific override → Big Blue Pick API → ``None`` (meaning: emit no
+        SET and let the compute project's GCP-level reservation assignment apply as-is). Static
+        overrides win over Pick API so that deliberately routed queries don't get re-routed
+        behind the user's back.
+        """
+        if sql_script.table_ref in self.script_specific_reservations:
+            return self.script_specific_reservations[sql_script.table_ref]
+        if self.big_blue_pick_api is not None:
+            return self.big_blue_pick_api.pick_reservation_for_script(script=sql_script)
+        return None
+
+    def _open_session(
+        self, reservation: str | None, extra_header_statements: list[str] | None = None
+    ) -> str | None:
+        """Open a BigQuery session, preloading ``SET @@reservation`` and any header statements.
+
+        Returns the session id, or ``None`` if nothing had to be preloaded (no reservation
+        override and no header statements) — in which case the caller should just run its query
+        without a session. Skipped entirely when ``dry_run`` is true, since dry-run doesn't
+        execute sessions.
+        """
         from google.cloud import bigquery
 
+        if self.dry_run:
+            return None
+        preload: list[str] = []
+        if reservation is not None:
+            preload.append(f"SET @@reservation = '{reservation}'")
+        if extra_header_statements:
+            preload.extend(extra_header_statements)
+        if not preload:
+            return None
+        code = "".join(f"{stmt};\n" for stmt in preload)
+        header_job_config = bigquery.QueryJobConfig(create_session=True)
+        job = self.client.query(code, job_config=header_job_config)
+        job.result()
+        if job.session_info is None or job.session_info.session_id is None:
+            raise RuntimeError(
+                "BigQuery did not return a session id after `create_session=True`; cannot "
+                "propagate SET @@reservation or header statements to the main query"
+            )
+        return job.session_info.session_id
+
+    @staticmethod
+    def _attach_session(job_config: bigquery.QueryJobConfig, session_id: str | None):
+        if session_id is None:
+            return
+        from google.cloud import bigquery
+
+        job_config.connection_properties = [
+            bigquery.ConnectionProperty(key="session_id", value=session_id)
+        ]
+
+    def materialize_sql_script(self, sql_script: scripts.SQLScript) -> BigQueryJob:
         destination = BigQueryDialect.convert_table_ref_to_bigquery_table_reference(
             table_ref=sql_script.table_ref, project=self.write_project_id
         )
@@ -405,7 +431,6 @@ class BigQueryClient(BigBluePickAPI):
             for field in (sql_script.fields or [])
             if FieldTag.CLUSTERING_FIELD in field.tags
         ]
-        clustering_fields = []
         # Remove duplicates but preserve order
         clustering_fields = list(
             dict.fromkeys([*default_clustering_fields, *tagged_clustering_fields])
@@ -421,31 +446,20 @@ class BigQueryClient(BigBluePickAPI):
             ),
         )
 
-        # Determine which client to use
-        client = self.determine_client_for_script(sql_script=sql_script)
-        if client.project != self.compute_project_id:
+        reservation = self.determine_reservation_for_script(sql_script=sql_script)
+        if reservation is not None:
             lea.log.info(
-                f"Using compute project {client.project!r} for materializing {sql_script.table_ref}"
+                f"Using reservation {reservation!r} for materializing {sql_script.table_ref}"
             )
-
-        # Run header statements if there are any
-        if sql_script.header_statements:
-            code = "".join(f"{hs};\n" for hs in sql_script.header_statements)
-            header_job_config = bigquery.QueryJobConfig(create_session=True)
-            job = client.query(code, job_config=header_job_config)
-            job.result()
-            session_id = job.session_info.session_id  # type: ignore
-        else:
-            session_id = None
-
-        if session_id is not None:
-            job_config.connection_properties = [
-                bigquery.ConnectionProperty(key="session_id", value=session_id)
-            ]
+        session_id = self._open_session(
+            reservation=reservation,
+            extra_header_statements=list(sql_script.header_statements) or None,
+        )
+        self._attach_session(job_config, session_id)
 
         return BigQueryJob(
             client=self,
-            query_job=client.query(
+            query_job=self.client.query(
                 query=sql_script.query,
                 job_config=job_config,
                 location=self.location,
@@ -460,11 +474,13 @@ class BigQueryClient(BigBluePickAPI):
         raise ValueError("Unsupported script type")
 
     def query_sql_script(self, sql_script: scripts.SQLScript) -> BigQueryJob:
-        client = self.determine_client_for_script(sql_script=sql_script)
         job_config = self.make_job_config(script=sql_script)
+        reservation = self.determine_reservation_for_script(sql_script=sql_script)
+        session_id = self._open_session(reservation=reservation)
+        self._attach_session(job_config, session_id)
         return BigQueryJob(
             client=self,
-            query_job=client.query(
+            query_job=self.client.query(
                 query=sql_script.query,
                 job_config=job_config,
                 location=self.location,
@@ -475,8 +491,6 @@ class BigQueryClient(BigBluePickAPI):
     def clone_table(
         self, from_table_ref: scripts.TableRef, to_table_ref: scripts.TableRef
     ) -> BigQueryJob:
-        from google.cloud import bigquery
-
         destination = BigQueryDialect.convert_table_ref_to_bigquery_table_reference(
             table_ref=to_table_ref, project=self.write_project_id
         )
@@ -486,16 +500,10 @@ class BigQueryClient(BigBluePickAPI):
 
         # First, delete the destination table if it exists. We need to do this because the existing
         # table potentially has a different clustering configuration, which cannot be changed with
-        # a CLONE.
-        delete_code = f"""
-        DROP TABLE IF EXISTS {destination};
-        """
-        header_job_config = bigquery.QueryJobConfig(create_session=True)
-        job = self.default_client.query(delete_code, job_config=header_job_config)
-        job.result()
-        assert job.session_info is not None
-        session_id = job.session_info.session_id
-        assert session_id is not None
+        # a CLONE. Run in a session so the CLONE that follows sees the DROP even if BQ takes a
+        # moment to propagate it.
+        delete_code = f"DROP TABLE IF EXISTS {destination}"
+        session_id = self._open_session(reservation=None, extra_header_statements=[delete_code])
 
         # Now, clone the source table to the destination.
         clone_code = f"""
@@ -506,14 +514,12 @@ class BigQueryClient(BigBluePickAPI):
             script=scripts.SQLScript(
                 table_ref=to_table_ref, code=clone_code, sql_dialect=BigQueryDialect(), fields=[]
             ),
-            connection_properties=[bigquery.ConnectionProperty(key="session_id", value=session_id)],
         )
+        self._attach_session(job_config, session_id)
 
         return BigQueryJob(
             client=self,
-            query_job=self.default_client.query(
-                clone_code, job_config=job_config, location=self.location
-            ),
+            query_job=self.client.query(clone_code, job_config=job_config, location=self.location),
             destination=destination,
         )
 
@@ -550,7 +556,7 @@ class BigQueryClient(BigBluePickAPI):
         )
         return BigQueryJob(
             client=self,
-            query_job=self.default_client.query(
+            query_job=self.client.query(
                 delete_and_insert_code, job_config=job_config, location=self.location
             ),
             destination=destination,
@@ -573,7 +579,7 @@ class BigQueryClient(BigBluePickAPI):
         )
         return BigQueryJob(
             client=self,
-            query_job=self.default_client.query(
+            query_job=self.client.query(
                 delete_code, job_config=job_config, location=self.location
             ),
         )
@@ -583,7 +589,7 @@ class BigQueryClient(BigBluePickAPI):
         SELECT table_id, row_count, size_bytes, last_modified_time
         FROM `{self.write_project_id}.{dataset_name}.__TABLES__`
         """
-        job = self.default_client.query(query, location=self.location)
+        job = self.client.query(query, location=self.location)
         return {
             BigQueryDialect.parse_table_ref(
                 f"{self.write_project_id}.{dataset_name}.{row['table_id']}"
@@ -602,7 +608,7 @@ class BigQueryClient(BigBluePickAPI):
         SELECT table_name, column_name
         FROM `{self.write_project_id}.{dataset_name}.INFORMATION_SCHEMA.COLUMNS`
         """
-        job = self.default_client.query(query, location=self.location)
+        job = self.client.query(query, location=self.location)
         return {
             BigQueryDialect.parse_table_ref(
                 f"{self.write_project_id}.{dataset_name}.{table_name}"

--- a/lea/test_big_query.py
+++ b/lea/test_big_query.py
@@ -6,9 +6,9 @@ import pytest
 from google.auth.credentials import AnonymousCredentials
 
 from lea.conductor import Session
-from lea.databases import BigQueryClient, TableStats
+from lea.databases import ON_DEMAND_RESERVATION, BigBluePickAPI, BigQueryClient, TableStats
 from lea.dialects import BigQueryDialect
-from lea.scripts import Script, TableRef
+from lea.scripts import Script, SQLScript, TableRef
 
 DUMMY_TABLE_STATS = TableStats(n_rows=0, n_bytes=0, updated_at=None)
 
@@ -375,4 +375,80 @@ def test_incremental_field_but_no_incremental_table_selected_and_yet_dependency_
             WHERE name NOT IN ('Alice')
         )
         """,
+    )
+
+
+def _make_client(**kwargs) -> BigQueryClient:
+    return BigQueryClient(
+        credentials=AnonymousCredentials(),  # ty: ignore[invalid-argument-type]
+        location="EU",
+        write_project_id="write-project-id",
+        compute_project_id="compute-project-id",
+        **kwargs,
+    )
+
+
+def _sql_script(table_ref: TableRef) -> SQLScript:
+    return SQLScript(
+        table_ref=table_ref, code="SELECT 1", sql_dialect=BigQueryDialect(), fields=[]
+    )
+
+
+def test_determine_reservation_no_overrides():
+    """No Pick API, no script-specific map → the query inherits the project's assignment."""
+    client = _make_client()
+    assert (
+        client.determine_reservation_for_script(
+            _sql_script(TableRef("read", ("core",), "users", "test_project"))
+        )
+        is None
+    )
+
+
+def test_determine_reservation_script_specific():
+    """A mapping entry for this table_ref is used verbatim."""
+    table_ref = TableRef("read", ("core",), "users", "test_project")
+    reservation = "projects/P/locations/EU/reservations/R"
+    client = _make_client(script_specific_reservations={table_ref: reservation})
+
+    assert client.determine_reservation_for_script(_sql_script(table_ref)) == reservation
+    # Unrelated tables still inherit the project assignment.
+    other = TableRef("read", ("core",), "accounts", "test_project")
+    assert client.determine_reservation_for_script(_sql_script(other)) is None
+
+
+def test_script_specific_wins_over_pick_api(monkeypatch):
+    """Explicit per-script overrides trump whatever Pick API suggests."""
+    table_ref = TableRef("read", ("core",), "users", "test_project")
+    static_reservation = "projects/P/locations/EU/reservations/static"
+    client = _make_client(script_specific_reservations={table_ref: static_reservation})
+    client.big_blue_pick_api = BigBluePickAPI(
+        api_url="https://pick.example",
+        api_key="k",
+        reservation="projects/P/locations/EU/reservations/pick",
+    )
+    # Pick API would say ON-DEMAND, but the static mapping must win.
+    monkeypatch.setattr(
+        BigBluePickAPI, "call_pick_api", lambda self, path, body: {"pick": "ON-DEMAND"}
+    )
+
+    assert client.determine_reservation_for_script(_sql_script(table_ref)) == static_reservation
+
+
+def test_pick_api_used_when_no_script_specific(monkeypatch):
+    """Pick API fills in for tables not listed in the static mapping."""
+    table_ref = TableRef("read", ("core",), "users", "test_project")
+    client = _make_client()
+    client.big_blue_pick_api = BigBluePickAPI(
+        api_url="https://pick.example",
+        api_key="k",
+        reservation="projects/P/locations/EU/reservations/pick",
+    )
+    monkeypatch.setattr(
+        BigBluePickAPI, "call_pick_api", lambda self, path, body: {"pick": "ON-DEMAND"}
+    )
+
+    assert (
+        client.determine_reservation_for_script(_sql_script(table_ref))
+        == ON_DEMAND_RESERVATION
     )


### PR DESCRIPTION
## Context

BigQuery now supports [setting a reservation per query](https://docs.cloud.google.com/bigquery/docs/reservations-assignments#sql_3) via the `@@reservation` system variable:

```sql
SET @@reservation = 'projects/P/locations/L/reservations/R';  -- run in R
SET @@reservation = 'none';                                   -- force on-demand
```

lea previously routed queries between compute projects with different reservation assignments, so `BigQueryClient` juggled a dict of `bigquery.Client` instances. This PR replaces that with a single client and picks reservations via SQL.

## Changes

- **`BigQueryClient`**: single `self.client`. Replaces `script_specific_compute_project_ids` with `script_specific_reservations`. Adds `determine_reservation_for_script` and a `_open_session`/`_attach_session` pair that emits `SET @@reservation = '<value>'` inside a BQ session and carries it to the main query via `session_id`. Skips the SET when a script has no override (the compute project's GCP-assigned reservation applies) and in dry-run.
- **`BigBluePickAPI`**: one constructor arg (`reservation`). ON-DEMAND picks map to `'none'`, RESERVATION picks map to that string. `BigQueryClient` no longer inherits from it — composition only.
- **Precedence**: `LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS` > Pick API > project's GCP assignment. Static overrides deliberately win so routed scripts aren't re-routed behind the user's back.
- **Env vars**:
  - `LEA_BQ_SCRIPT_SPECIFIC_COMPUTE_PROJECT_IDS` → `LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS` (value: `"none"` or `projects/.../reservations/...`; parsed with validation so typos surface at startup).
  - `LEA_BQ_BIG_BLUE_PICK_API_{ON_DEMAND,REVERVATION}_PROJECT_ID` → `LEA_BQ_BIG_BLUE_PICK_API_RESERVATION` (single var; fixes the `REVERVATION` typo).
- **Drive-by**: `BigQueryJob.metadata` was reading `statistics.reservationUsage[0].name`, which is not populated on real jobs — switched to `statistics.reservation_id`. The log line now correctly reports `reservation billing (<id>)` / `on-demand billing`.

## Caveat — overriding to on-demand is gated

During validation, `SET @@reservation = 'none'` (or equivalently `bq query --reservation_id=none`) on `int-data-kaya-prod` was rejected:

> Override to 'none' is not enabled. The option 'reservation_override_mode' is set to 'RESERVATION_OVERRIDE_MODE_UNSPECIFIED'. See https://cloud.google.com/bigquery/docs/default-configuration for configuration details.

The referenced doc does not list this option or its enum; ~25 brute-force guesses all failed. Routing *to* a reservation path works fine out of the box; a GCP support ticket is probably needed to unlock the on-demand override. This refactor is still strictly better regardless (single client, single compute project, typo fix, fixed billing-model log line).

## Test plan

- [x] `uv run pytest lea/` — 75/75 pass (4 new tests for reservation resolution precedence).
- [x] Live dry-run: `lea run --scripts ../carbonfact/kaya/scripts --select core.accounts --dry-run --production` with `LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS={"kaya.core__accounts":"projects/int-data-kaya-prod/locations/EU/reservations/default"}` — logs `Using reservation '<path>' for materializing ...` and `SUCCESS ... (reservation billing (int-data-kaya-prod:EU.default))`.
- [ ] Live run without `--dry-run` once the repo owner is ready.
- [ ] Override-to-on-demand path — blocked until `reservation_override_mode` is enabled at the project/org level.

## Migration

Existing users must:
1. Replace `LEA_BQ_SCRIPT_SPECIFIC_COMPUTE_PROJECT_IDS={...}` with `LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS={...}` whose values are `"none"` or `projects/.../reservations/...`.
2. Replace `LEA_BQ_BIG_BLUE_PICK_API_ON_DEMAND_PROJECT_ID` / `LEA_BQ_BIG_BLUE_PICK_API_REVERVATION_PROJECT_ID` with a single `LEA_BQ_BIG_BLUE_PICK_API_RESERVATION=projects/.../reservations/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route BigQuery jobs via per-query reservations using `SET @@reservation` instead of switching compute projects. This simplifies config to a single client and improves billing visibility.

- **Refactors**
  - Use one `BigQueryClient` and set reservations in a session (`SET @@reservation`), carried to the main query via `session_id`.
  - Replace script-specific compute projects with `script_specific_reservations`. Precedence: `LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS` > Big Blue Pick API > project's assignment.
  - Big Blue Pick API now maps picks to reservations: `ON-DEMAND` → `'none'`, `RESERVATION` → `LEA_BQ_BIG_BLUE_PICK_API_RESERVATION`. Composition only.
  - Fix billing logs by reading `statistics.reservation_id`; now reports `reservation billing (<id>)` or `on-demand billing`.
  - Note: forcing on-demand (`'none'`) may be disabled by your project's `reservation_override_mode`.

- **Migration**
  - Replace `LEA_BQ_SCRIPT_SPECIFIC_COMPUTE_PROJECT_IDS` with `LEA_BQ_SCRIPT_SPECIFIC_RESERVATIONS` values: `"none"` or `projects/.../reservations/...`.
  - Replace `LEA_BQ_BIG_BLUE_PICK_API_ON_DEMAND_PROJECT_ID` and `LEA_BQ_BIG_BLUE_PICK_API_REVERVATION_PROJECT_ID` with `LEA_BQ_BIG_BLUE_PICK_API_RESERVATION`.

<sup>Written for commit 47a3a447b12c53cea09b2bae0d53dc797792e1c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

