### PR TITLE
feat: add LEA_DUCKDB_SECRETS, replace LEA_DUCKLAKE_SECRET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.19.0
+
+### Breaking changes
+
+- Replaced `LEA_DUCKLAKE_SECRET` with `LEA_DUCKDB_SECRETS` and `LEA_QUACK_DUCKLAKE_SECRET` with `LEA_QUACK_DUCKDB_SECRETS`. The new variables support multiple semicolon-separated secrets and work across all DuckDB-based warehouses (DuckDB, MotherDuck, DuckLake), not just DuckLake. This enables extensions like [gsheets](https://duckdb-gsheets.com/) that require a `CREATE SECRET` statement.
+
 ## v0.18.0
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -126,7 +126,11 @@ LEA_WAREHOUSE=duckdb
 LEA_DUCKDB_PATH=duckdb.db
 # Optional
 LEA_DUCKDB_EXTENSIONS=parquet,httpfs
+# Optional — semicolon-separated CREATE SECRET bodies
+LEA_DUCKDB_SECRETS=TYPE gsheet, PROVIDER access_token, TOKEN 'your_token'
 ```
+
+`LEA_DUCKDB_SECRETS` creates [DuckDB secrets](https://duckdb.org/docs/current/configuration/secrets_manager) before running queries. This is useful for extensions like [gsheets](https://duckdb-gsheets.com/) that require authentication. Multiple secrets can be separated with `;`.
 
 ### MotherDuck
 
@@ -139,6 +143,8 @@ MOTHERDUCK_TOKEN=<get this from https://app.motherduck.com/settings/tokens>
 LEA_MOTHERDUCK_DATABASE=bike_sharing
 # Optional
 LEA_DUCKDB_EXTENSIONS=parquet,httpfs
+# Optional
+LEA_DUCKDB_SECRETS=...
 ```
 
 ### DuckLake
@@ -159,26 +165,26 @@ LEA_DUCKLAKE_DATA_PATH=/path/to/data
 LEA_WAREHOUSE=ducklake
 LEA_DUCKLAKE_CATALOG_DATABASE="postgres:dbname=ducklake_catalog host=myhost.com user=myuser password=mypass"
 LEA_DUCKLAKE_DATA_PATH=s3://my-bucket/data
-LEA_DUCKLAKE_SECRET="TYPE s3, KEY_ID 'key_id', SECRET 'secret_key'"
+LEA_DUCKDB_SECRETS="TYPE s3, KEY_ID 'key_id', SECRET 'secret_key'"
 LEA_DUCKDB_EXTENSIONS=postgres
 ```
 
 **Cloud storage**
 
-For cloud storage, set `LEA_DUCKLAKE_SECRET` to the body of a DuckDB [`CREATE SECRET`](https://duckdb.org/docs/current/configuration/secrets_manager) statement. This works with any secret type DuckDB supports (S3, GCS, R2, Azure, etc.).
+For cloud storage, set `LEA_DUCKDB_SECRETS` to the body of a DuckDB [`CREATE SECRET`](https://duckdb.org/docs/current/configuration/secrets_manager) statement. This works with any secret type DuckDB supports (S3, GCS, R2, Azure, etc.).
 
 ```sh
 # R2
 LEA_DUCKLAKE_DATA_PATH=r2://my-bucket/data
-LEA_DUCKLAKE_SECRET="TYPE r2, KEY_ID 'key_id', SECRET 'secret_key', ACCOUNT_ID 'my_account_id'"
+LEA_DUCKDB_SECRETS="TYPE r2, KEY_ID 'key_id', SECRET 'secret_key', ACCOUNT_ID 'my_account_id'"
 
 # GCS (requires HMAC keys)
 LEA_DUCKLAKE_DATA_PATH=gcs://my-bucket/data
-LEA_DUCKLAKE_SECRET="TYPE gcs, KEY_ID 'GOOG1E...', SECRET '...'"
+LEA_DUCKDB_SECRETS="TYPE gcs, KEY_ID 'GOOG1E...', SECRET '...'"
 
 # S3
 LEA_DUCKLAKE_DATA_PATH=s3://my-bucket/data
-LEA_DUCKLAKE_SECRET="TYPE s3, KEY_ID 'key_id', SECRET 'secret_key', ENDPOINT 'storage.googleapis.com'"
+LEA_DUCKDB_SECRETS="TYPE s3, KEY_ID 'key_id', SECRET 'secret_key', ENDPOINT 'storage.googleapis.com'"
 ```
 
 ## Usage
@@ -313,7 +319,7 @@ LEA_QUACK_DUCKLAKE_DATA_PATH=/path/to/quack/data
 ```sh
 LEA_QUACK_DUCKLAKE_CATALOG_DATABASE=quack.ducklake
 LEA_QUACK_DUCKLAKE_DATA_PATH=gcs://my-bucket/quack/data
-LEA_QUACK_DUCKLAKE_SECRET="TYPE gcs, KEY_ID 'GOOG1E...', SECRET '...'"
+LEA_QUACK_DUCKDB_SECRETS="TYPE gcs, KEY_ID 'GOOG1E...', SECRET '...'"
 ```
 
 You can push the DuckLake tables back to your warehouse with `--quack-push`:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ LEA_DUCKDB_PATH=duckdb.db
 # Optional
 LEA_DUCKDB_EXTENSIONS=parquet,httpfs
 # Optional — semicolon-separated CREATE SECRET bodies
-LEA_DUCKDB_SECRETS=TYPE gsheet, PROVIDER access_token, TOKEN 'your_token'
+LEA_DUCKDB_SECRETS="TYPE gsheet, PROVIDER access_token, TOKEN 'your_token'"
 ```
 
 `LEA_DUCKDB_SECRETS` creates [DuckDB secrets](https://duckdb.org/docs/current/configuration/secrets_manager) before running queries. This is useful for extensions like [gsheets](https://duckdb-gsheets.com/) that require authentication. Multiple secrets can be separated with `;`.

--- a/examples/quack/README.md
+++ b/examples/quack/README.md
@@ -77,10 +77,10 @@ This finishes in under a second.
 
 ## DuckLake storage
 
-By default, DuckLake stores data locally in `./quack_data/` as Parquet files. You can also use cloud storage by setting `LEA_QUACK_DUCKLAKE_SECRET` to the body of a DuckDB [`CREATE SECRET`](https://duckdb.org/docs/current/configuration/secrets_manager) statement:
+By default, DuckLake stores data locally in `./quack_data/` as Parquet files. You can also use cloud storage by setting `LEA_QUACK_DUCKDB_SECRETS` to the body of a DuckDB [`CREATE SECRET`](https://duckdb.org/docs/current/configuration/secrets_manager) statement:
 
 ```sh
 LEA_QUACK_DUCKLAKE_CATALOG_DATABASE=quack.ducklake
 LEA_QUACK_DUCKLAKE_DATA_PATH=s3://my-bucket/quack-data/
-LEA_QUACK_DUCKLAKE_SECRET="TYPE s3, KEY_ID 'key_id', SECRET 'secret_key', ENDPOINT 'storage.googleapis.com'"
+LEA_QUACK_DUCKDB_SECRETS="TYPE s3, KEY_ID 'key_id', SECRET 'secret_key', ENDPOINT 'storage.googleapis.com'"
 ```

--- a/examples/r2-ducklake/README.md
+++ b/examples/r2-ducklake/README.md
@@ -10,11 +10,11 @@ LEA_USERNAME=max
 LEA_WAREHOUSE=ducklake
 LEA_DUCKLAKE_CATALOG_DATABASE=metadata.ducklake
 LEA_DUCKLAKE_DATA_PATH=r2://your-bucket-name
-LEA_DUCKLAKE_SECRET=TYPE r2, KEY_ID 'your_access_key_id', SECRET 'your_secret_access_key', ACCOUNT_ID 'your_account_id'
+LEA_DUCKDB_SECRETS=TYPE r2, KEY_ID 'your_access_key_id', SECRET 'your_secret_access_key', ACCOUNT_ID 'your_account_id'
 " > .env
 ```
 
-The `LEA_DUCKLAKE_SECRET` value is the body of a DuckDB [`CREATE SECRET`](https://duckdb.org/docs/current/configuration/secrets_manager) statement. This same pattern works for S3, GCS, Azure, etc.
+The `LEA_DUCKDB_SECRETS` value is the body of a DuckDB [`CREATE SECRET`](https://duckdb.org/docs/current/configuration/secrets_manager) statement. Multiple secrets can be separated with `;`. This works for S3, GCS, R2, Azure, etc.
 
 Symlink the jaffle shop scripts:
 

--- a/lea/cli.py
+++ b/lea/cli.py
@@ -100,11 +100,13 @@ def quack_ui(env_file):
             "LEA_QUACK_DUCKLAKE_CATALOG_DATABASE and LEA_QUACK_DUCKLAKE_DATA_PATH must be set"
         )
 
-    secret_sql = ""
-    if secret := os.environ.get("LEA_QUACK_DUCKLAKE_SECRET"):
-        secret_sql = f"CREATE SECRET ({secret}); "
+    secrets_sql = ""
+    for secret in os.environ.get("LEA_QUACK_DUCKDB_SECRETS", "").split(";"):
+        secret = secret.strip()
+        if secret:
+            secrets_sql += f"CREATE SECRET ({secret}); "
     setup_sql = (
-        f"{secret_sql}"
+        f"{secrets_sql}"
         "INSTALL ducklake; LOAD ducklake; "
         "INSTALL ui FROM core_nightly; LOAD ui; "
         f"ATTACH 'ducklake:{catalog}' AS quack_ducklake (DATA_PATH '{data_path}', AUTOMATIC_MIGRATION TRUE); "

--- a/lea/conductor.py
+++ b/lea/conductor.py
@@ -197,8 +197,10 @@ class Conductor:
 
             # Set up DuckLake
             conn = quack_database_client.connection
-            if secret := os.environ.get("LEA_QUACK_DUCKLAKE_SECRET"):
-                conn.execute(f"CREATE SECRET ({secret});")
+            for secret in os.environ.get("LEA_QUACK_DUCKDB_SECRETS", "").split(";"):
+                secret = secret.strip()
+                if secret:
+                    conn.execute(f"CREATE SECRET ({secret});")
 
             conn.execute(
                 f"""
@@ -243,6 +245,19 @@ class Conductor:
             database_client.create_dataset(write_dataset)
 
             if isinstance(database_client, databases.DuckDBClient):
+                for extension in os.environ.get("LEA_DUCKDB_EXTENSIONS", "").split(","):
+                    extension = extension.strip()
+                    if extension:
+                        lea.log.info(f"🔩 Loading extension {extension}")
+                        database_client.connection.execute(f"INSTALL '{extension}';")
+                        database_client.connection.execute(f"LOAD '{extension}';")
+
+                for secret in os.environ.get("LEA_DUCKDB_SECRETS", "").split(";"):
+                    secret = secret.strip()
+                    if secret:
+                        lea.log.info("🔩 Creating secret")
+                        database_client.connection.execute(f"CREATE SECRET ({secret});")
+
                 if self.warehouse == databases.Warehouse.DUCKDB:
                     lea.log.info(
                         f"🔩 Using DuckDB database at {database_client.database_path.absolute()}"
@@ -256,8 +271,6 @@ class Conductor:
                     if isinstance(database_client, databases.MotherDuckClient):
                         database_client.set_active_database(write_dataset)
                 elif self.warehouse == databases.Warehouse.DUCKLAKE:
-                    if secret := os.environ.get("LEA_DUCKLAKE_SECRET"):
-                        database_client.connection.execute(f"CREATE SECRET ({secret});")
                     database_client.connection.execute(
                         f"""
                         ATTACH 'ducklake:{os.environ["LEA_DUCKLAKE_CATALOG_DATABASE"]}' AS my_ducklake (
@@ -268,14 +281,6 @@ class Conductor:
                     )
                     if isinstance(database_client, databases.DuckLakeClient):
                         database_client.set_active_database("my_ducklake")
-
-                # When using DuckDB, we need to create schema for the tables
-                for extension in os.environ.get("LEA_DUCKDB_EXTENSIONS", "").split(","):
-                    extension = extension.strip()
-                    if extension:
-                        lea.log.info(f"🔩 Loading extension {extension}")
-                        database_client.connection.execute(f"INSTALL '{extension}';")
-                        database_client.connection.execute(f"LOAD '{extension}';")
 
                 lea.log.info("🔩 Creating schemas")
                 schema_names = set(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lea-cli"
-version = "0.18.0"
+version = "0.19.0"
 description = "A minimalist alternative to dbt"
 authors = [{name = "Max Halford", email = "maxhalford25@gmail.com"}]
 requires-python = ">=3.11,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ wheels = [
 
 [[package]]
 name = "lea-cli"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds `LEA_DUCKDB_SECRETS` (semicolon-separated `CREATE SECRET` bodies) that works across all DuckDB-based warehouses (DuckDB, MotherDuck, DuckLake)
- Replaces the DuckLake-specific `LEA_DUCKLAKE_SECRET` and `LEA_QUACK_DUCKLAKE_SECRET` with `LEA_DUCKDB_SECRETS` and `LEA_QUACK_DUCKDB_SECRETS`
- Moves extension/secret loading before warehouse-specific setup so DuckLake `ATTACH` can use the credentials
- Bumps version to 0.19.0

Closes #188

## Test plan

- [ ] Verify `LEA_DUCKDB_SECRETS` works with `LEA_WAREHOUSE=duckdb` (e.g. gsheets extension)
- [ ] Verify `LEA_DUCKDB_SECRETS` works with DuckLake for cloud storage (R2/S3/GCS)
- [ ] Verify multiple semicolon-separated secrets are created
- [ ] Verify `LEA_QUACK_DUCKDB_SECRETS` works in quack mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `LEA_DUCKDB_SECRETS` (and `LEA_QUACK_DUCKDB_SECRETS`) to create DuckDB secrets across DuckDB, MotherDuck, and DuckLake using semicolon-separated CREATE SECRET bodies. Extensions and secrets now load before warehouse setup so DuckLake ATTACH can use the credentials; docs and examples updated; enables auth for extensions like `gsheets`.

- **Migration**
  - Replace `LEA_DUCKLAKE_SECRET` with `LEA_DUCKDB_SECRETS` and `LEA_QUACK_DUCKLAKE_SECRET` with `LEA_QUACK_DUCKDB_SECRETS`.
  - Breaking change in v0.19.0.

<sup>Written for commit 94a07619b7e8ad31eeb448a84aa8ddc5253b2218. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

