### PR TITLE
Cap sqlglot below 7-day-old releases, bump to 0.19.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lea-cli"
-version = "0.19.1"
+version = "0.19.2"
 description = "A minimalist alternative to dbt"
 authors = [{name = "Max Halford", email = "maxhalford25@gmail.com"}]
 requires-python = ">=3.11,<4"
@@ -14,7 +14,12 @@ dependencies = [
   "pandas>=2.1.3,<4",
   "python-dotenv>=1.0.0,<2",
   "rich>=13.5.3,<16",
-  "sqlglot>=30.2",
+  # Upper bound pins sqlglot to a release old enough to clear the 7-day
+  # minimum-package-age gate our downstream (carbonfact/carbonfact kaya) CI
+  # enforces via Aikido Safe-Chain. Without it, resolvers pick the newest
+  # sqlglot, which is often <7 days old and gets a 403. Raise deliberately
+  # once the target release has aged past the gate.
+  "sqlglot>=30.2,<30.15",
   "rsa>=4.7,<5",
   "google-cloud-bigquery-storage>=2.27.0,<3",
   "requests>=2.32.3,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "lea-cli"
-version = "0.19.1"
+version = "0.19.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -613,7 +613,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3,<3" },
     { name = "rich", specifier = ">=13.5.3,<16" },
     { name = "rsa", specifier = ">=4.7,<5" },
-    { name = "sqlglot", specifier = ">=30.2" },
+    { name = "sqlglot", specifier = ">=30.2,<30.15" },
 ]
 
 [package.metadata.requires-dev]
@@ -1265,11 +1265,11 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "30.15.0"
+version = "30.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/fb/c43bfdc662bd6fcdf93158f9239b975ac01b775cfcb56015913fee9b95e2/sqlglot-30.15.0.tar.gz", hash = "sha256:fe5412f4da61075f532d3de2482144bf7139028980a37bbd79fb016c49dc2dbe", size = 5973319, upload-time = "2026-08-04T17:37:12.831Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/cd/39a94f0f98076ee8e7c7c38fd4bba8d7845b0c629ff967057c64ef2c0989/sqlglot-30.14.0.tar.gz", hash = "sha256:df2ef5d2b8ca814313781f4ff35bf63e58f821ef517eeddbd523c19a61fa9bb9", size = 5944410, upload-time = "2026-07-27T11:23:30.698Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/28/f1e99aca0c23e2406dc8727555476647d58c2d6315d7d8101dffbb2cbc0f/sqlglot-30.15.0-py3-none-any.whl", hash = "sha256:594da0bc9d020edfb9982fd56b61dc93483cb24edca5ed1b3bb17937ba9b59bc", size = 731813, upload-time = "2026-08-04T17:37:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ec/a729883ceda22dcd9117ce182f64d884bf494e72c4dfce00c2ad0a5978e1/sqlglot-30.14.0-py3-none-any.whl", hash = "sha256:fc768e24889d63a5e1237dea7ad305e5ffb4356a98b0bed828f89591ebcd3636", size = 719007, upload-time = "2026-07-27T11:23:28.637Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- Cap `sqlglot` to `>=30.2,<30.15` (resolves to `30.14.0`).
- Bump `lea-cli` to `0.19.2`.

## Why

`lea-cli` declared `sqlglot>=30.2` with no upper bound, so resolvers pick the newest `sqlglot`. Our downstream monorepo (`carbonfact/carbonfact`, the `kaya` package) installs CI dependencies through **Aikido Safe-Chain**, which enforces a **7-day minimum package age** company-wide. When the newest `sqlglot` is under 7 days old (as `30.16.0` was, published 2026-08-10), the install fails:

> HTTP status client error (403 Forbidden - blocked by safe-chain direct download minimum package age (sqlglot@30.16.0))

Capping to `<30.15` resolves `sqlglot` to `30.14.0` (published 2026-07-27, well past the gate). The bound should be raised deliberately once a newer `sqlglot` has aged past the 7-day window; Dependabot will nudge it up over time.

## Validation

- `uv sync --locked` clean
- `uv run ruff check .` passes
- `uv run pytest` -> 71 passed

## Release

Merging this does not publish. Publishing to PyPI is triggered by pushing a `v0.19.2` tag (`.github/workflows/publish.yml`). Once `lea-cli 0.19.2` is on PyPI, `carbonfact/carbonfact` bumps `kaya`'s `lea-cli>=0.19.2` and relocks (see carbonfact/carbonfact#14539).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap `sqlglot` to `<30.15` to avoid Aikido Safe-Chain’s 7‑day package-age gate that breaks CI, and bump `lea-cli` to `0.19.2`. This resolves installs to `sqlglot 30.14.0` and unblocks downstream `carbonfact/carbonfact` (`kaya`) pipelines.

- **Dependencies**
  - Set `sqlglot` to `>=30.2,<30.15` (resolves to `30.14.0`).
  - Bump `lea-cli` to `0.19.2`.

<sup>Written for commit 266881d23dd15bc29c7b93a5c7d099255e9ece1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carbonfact/lea/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

