### PR TITLE
fix: remove sqlglot upper bound, bump to 0.19.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lea-cli"
-version = "0.19.2"
+version = "0.19.3"
 description = "A minimalist alternative to dbt"
 authors = [{name = "Max Halford", email = "maxhalford25@gmail.com"}]
 requires-python = ">=3.11,<4"
@@ -14,12 +14,7 @@ dependencies = [
   "pandas>=2.1.3,<4",
   "python-dotenv>=1.0.0,<2",
   "rich>=13.5.3,<16",
-  # Upper bound pins sqlglot to a release old enough to clear the 7-day
-  # minimum-package-age gate our downstream (carbonfact/carbonfact kaya) CI
-  # enforces via Aikido Safe-Chain. Without it, resolvers pick the newest
-  # sqlglot, which is often <7 days old and gets a 403. Raise deliberately
-  # once the target release has aged past the gate.
-  "sqlglot>=30.2,<30.15",
+  "sqlglot>=30.2",
   "rsa>=4.7,<5",
   "google-cloud-bigquery-storage>=2.27.0,<3",
   "requests>=2.32.3,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "lea-cli"
-version = "0.19.2"
+version = "0.19.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -613,7 +613,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3,<3" },
     { name = "rich", specifier = ">=13.5.3,<16" },
     { name = "rsa", specifier = ">=4.7,<5" },
-    { name = "sqlglot", specifier = ">=30.2,<30.15" },
+    { name = "sqlglot", specifier = ">=30.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## What

- Remove the `<30.15` upper bound on `sqlglot` added in #207; back to `sqlglot>=30.2`.
- Bump `lea-cli` to `0.19.3`.

## Why

#207 capped `sqlglot` to work around Aikido Safe-Chain's 7-day minimum-package-age gate in `carbonfact/carbonfact`'s CI. That gate is specific to one downstream consumer's CI configuration, not a constraint of `lea-cli` itself. `lea-cli` is a library: pinning an upper bound on a transitive dependency forces that constraint onto every consumer's resolver, which can create version conflicts for consumers who need a newer `sqlglot` for unrelated reasons. The 7-day gate should be handled downstream (e.g. by pinning in `kaya`'s own lockfile, or via an Aikido allowlist), not by `lea-cli` capping the dependency for everyone.

## Validation

- `uv lock` resolves cleanly (still picks `sqlglot==30.14.0` today, since nothing forces an upgrade)
- `uv sync --locked` clean
- `uv run ruff check .` passes
- `uv run pytest` -> 71 passed

## Release

Merging this does not publish. Once merged, the "Publishing" workflow will be triggered manually (`workflow_dispatch` on `main`), matching this repo's established release pattern, to ship `lea-cli 0.19.3` to PyPI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `sqlglot` upper bound so consumers can use newer versions without conflicts. Bumps `lea-cli` to `0.19.3`; the prior cap was only to satisfy a downstream CI package-age gate.

<sup>Written for commit 1121efaeb7964b378461313ab46218c0cd7217c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carbonfact/lea/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

