### PR TITLE
fix: bump gitpython to 3.1.62

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -320,14 +320,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.62"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/db/3ca813cbacb23ab6fe46ff38a9b5ef8e73e970c8051f2ce903aacafe0446/gitpython-3.1.62.tar.gz", hash = "sha256:1791de66309bc0c7cfca40bf8d2e3de7ca091cbf94e6051be1ad0722c61062af", size = 231728, upload-time = "2026-09-07T02:57:21.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/0b/29d7965215f8ef830a7ca1f42997fe13e5693d85e9edb18f938d063ef5f2/gitpython-3.1.62-py3-none-any.whl", hash = "sha256:7002251225e10e29d2e1f49e6532613fe5d5d9f0b6f1f02997a52b38fe56899e", size = 222753, upload-time = "2026-09-07T02:57:19.762Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `gitpython` 3.1.58 → 3.1.62, resolving 3 unpatched Aikido findings: CVE-2026-78676 (critical), CVE-2026-78675 (high), CVE-2026-78677 (high)
- In-range per `pyproject.toml` (`gitpython>=3.1.43,<4`), so this is a routine lockfile-only bump via `uv lock --upgrade-package gitpython`

## Context
lea's weekly dependabot hadn't caught these up yet (next scheduled run 2026-09-15); filed manually given the critical severity.

## Test plan
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `gitpython` from 3.1.58 to 3.1.62 in `uv.lock` to resolve CVE-2026-78676 (critical), CVE-2026-78675 (high), and CVE-2026-78677 (high). The version is already in range per `pyproject.toml` (`gitpython>=3.1.43,<4`), so this is a lockfile-only update with no code changes required.

<sup>Written for commit 54d4cd01902e91b4cb7c5d3b7d6e26757f7b971a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/carbonfact/lea/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

